### PR TITLE
release v0.9.5

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,8 +3,16 @@
 Release History
 ===============
 
+0.9.5
++++++
+* Limit minimal python version to 3.8 (#98)(#99)(#101)
+* Fix issue when rename commands in cfg_editor (#100)
+* Remove python-Levenshtein reliance (#102)
+* Disable paging for long running commands (#103)
+* Add provisioning state field verification in wait command generation (#104)
+
 0.9.4
-++++
++++++
 * Update docs (#94)(#95)(#96)
 
 0.9.3

--- a/src/aaz_dev/utils/config.py
+++ b/src/aaz_dev/utils/config.py
@@ -4,7 +4,7 @@ from packaging import version
 
 class Config:
 
-    MIN_CLI_CORE_VERSION = version.parse("2.38.0")
+    MIN_CLI_CORE_VERSION = version.parse("2.39.0")
 
     AAZ_PATH = os.environ.get("AAZ_PATH", None)
     SWAGGER_PATH = os.environ.get("AAZ_SWAGGER_PATH", None)

--- a/version.py
+++ b/version.py
@@ -1,5 +1,5 @@
 
-_MAJOR, _MINOR, _PATCH, _SUFFIX = ("0", "9", "4", "")
+_MAJOR, _MINOR, _PATCH, _SUFFIX = ("0", "9", "5", "")
 
 # _PATCH: On main and in a nightly release the patch should be one ahead of the last released build.
 # _SUFFIX: This is mainly for nightly builds which have the suffix ".dev$DATE". See


### PR DESCRIPTION
* Limit minimal python version to 3.8 (#98)(#99)(#101)
* Fix issue when rename commands in cfg_editor (#100)
* Remove python-Levenshtein reliance (#102)
* Disable paging for long running commands (#103)
* Add provisioning state field verification in wait command generation (#104)
