### PR TITLE
Release v0.11.2

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,12 @@
 Release History
 ===============
 
+0.11.2
+++++++
+* Fix cls argument base inherent (#136)
+* Fix reload swagger error if no arg change previously (#135)
+* Add delete confirmation for workspace delete (#134)
+
 0.11.1
 ++++++
 * Fix patch only not work in workspace editors (#132)

--- a/version.py
+++ b/version.py
@@ -1,5 +1,5 @@
 
-_MAJOR, _MINOR, _PATCH, _SUFFIX = ("0", "11", "1", "")
+_MAJOR, _MINOR, _PATCH, _SUFFIX = ("0", "11", "2", "")
 
 # _PATCH: On main and in a nightly release the patch should be one ahead of the last released build.
 # _SUFFIX: This is mainly for nightly builds which have the suffix ".dev$DATE". See


### PR DESCRIPTION
* Fix cls argument base inherent (#136)
* Fix reload swagger error if no arg change previously (#135)
* Add delete confirmation for workspace delete (#134)