### PR TITLE
release-v0.12.0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,11 @@
 Release History
 ===============
 
+0.12.0
+++++++
+* Disable Read only inherent in swagger translators (#139)
+* Enable register_callback decorator (#129)
+
 0.11.2
 ++++++
 * Fix cls argument base inherent (#136)

--- a/src/aaz_dev/utils/config.py
+++ b/src/aaz_dev/utils/config.py
@@ -4,7 +4,7 @@ from packaging import version
 
 class Config:
 
-    MIN_CLI_CORE_VERSION = version.parse("2.40.0")
+    MIN_CLI_CORE_VERSION = version.parse("2.41.0")
 
     AAZ_PATH = os.environ.get("AAZ_PATH", None)
     SWAGGER_PATH = os.environ.get("AAZ_SWAGGER_PATH", None)

--- a/version.py
+++ b/version.py
@@ -1,5 +1,5 @@
 
-_MAJOR, _MINOR, _PATCH, _SUFFIX = ("0", "11", "2", "")
+_MAJOR, _MINOR, _PATCH, _SUFFIX = ("0", "12", "0", "")
 
 # _PATCH: On main and in a nightly release the patch should be one ahead of the last released build.
 # _SUFFIX: This is mainly for nightly builds which have the suffix ".dev$DATE". See


### PR DESCRIPTION
* Disable Read only inherent in swagger translators (#139)
* Enable register_callback decorator (#129)