### PR TITLE
Release v0.13.0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,13 @@
 Release History
 ===============
 
+0.13.0
+++++++
+* Support free from dict for `"additionalProperties":True` swagger definition (#138)
+* Support command confirmation prompt modification (#141)
+* Fix duplicated option names detect when flatten argument (#142)
+* Fix reload swagger aug group name overwrite (#143)
+
 0.12.0
 ++++++
 * Disable Read only inherent in swagger translators (#139)

--- a/version.py
+++ b/version.py
@@ -1,5 +1,5 @@
 
-_MAJOR, _MINOR, _PATCH, _SUFFIX = ("0", "12", "0", "")
+_MAJOR, _MINOR, _PATCH, _SUFFIX = ("0", "13", "0", "")
 
 # _PATCH: On main and in a nightly release the patch should be one ahead of the last released build.
 # _SUFFIX: This is mainly for nightly builds which have the suffix ".dev$DATE". See


### PR DESCRIPTION
0.13.0
++++++
* Support free from dict for `"additionalProperties":True` swagger definition (#138)
* Support command confirmation prompt modification (#141)
* Fix duplicated option names detect when flatten argument (#142)
* Fix reload swagger aug group name overwrite (#143)
