### PR TITLE
release v0.15.0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,13 @@
 Release History
 ===============
 
+0.15.0
+++++++
+* Fix workspace export to aaz issue. (#148)
+* Ignore empty confirmation string in generated code. (#149)
+* Fix version and readiness parse issue in swagger file path (#150)
+* Fix class inheritance overwritten issue (#151)
+
 0.14.0
 ++++++
 * Support class type arguments `unwrap` and `flatten` (#145)

--- a/src/aaz_dev/utils/config.py
+++ b/src/aaz_dev/utils/config.py
@@ -4,7 +4,7 @@ from packaging import version
 
 class Config:
 
-    MIN_CLI_CORE_VERSION = version.parse("2.41.0")
+    MIN_CLI_CORE_VERSION = version.parse("2.42.0")
 
     AAZ_PATH = os.environ.get("AAZ_PATH", None)
     SWAGGER_PATH = os.environ.get("AAZ_SWAGGER_PATH", None)

--- a/version.py
+++ b/version.py
@@ -1,5 +1,5 @@
 
-_MAJOR, _MINOR, _PATCH, _SUFFIX = ("0", "14", "0", "")
+_MAJOR, _MINOR, _PATCH, _SUFFIX = ("0", "15", "0", "")
 
 # _PATCH: On main and in a nightly release the patch should be one ahead of the last released build.
 # _SUFFIX: This is mainly for nightly builds which have the suffix ".dev$DATE". See


### PR DESCRIPTION
* Fix workspace export to aaz issue. (#148)
* Ignore empty confirmation string in generated code. (#149)
* Fix version and readiness parse issue in swagger file path (#150)
* Fix class inheritance overwritten issue (#151)