### PR TITLE
Release v0.15.1

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,10 +3,16 @@
 Release History
 ===============
 
+0.15.1
+++++++
+* Fix `workspace` bug on class argument unwrap (#155)
+* Fix `workspace` reload issue for update command using patch (#156)
+* Optimize `generation` error message display when loading modules (#157)
+
 0.15.0
 ++++++
 * Fix workspace export to aaz issue. (#148)
-* Ignore empty confirmation string in generated code. (#149)
+* Ignore empty confirmation string in generated code (#149)
 * Fix version and readiness parse issue in swagger file path (#150)
 * Fix class inheritance overwritten issue (#151)
 

--- a/version.py
+++ b/version.py
@@ -1,5 +1,5 @@
 
-_MAJOR, _MINOR, _PATCH, _SUFFIX = ("0", "15", "0", "")
+_MAJOR, _MINOR, _PATCH, _SUFFIX = ("0", "15", "1", "")
 
 # _PATCH: On main and in a nightly release the patch should be one ahead of the last released build.
 # _SUFFIX: This is mainly for nightly builds which have the suffix ".dev$DATE". See


### PR DESCRIPTION
0.15.1
---
* Fix `workspace` bug on class argument unwrap (#155)
* Fix `workspace` reload issue for update command using patch (#156)
* Optimize `generation` error message display when loading modules (#157)