### PR TITLE
Release v0.16.0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,20 @@
 Release History
 ===============
 
+0.16.0
+++++++
+* Support build-in keywords in property name generation (#167)
+* Add portal CLI generator (#153)
+* Support to generate property name starts with digit (#166)
+* Support to modify default for array, dict and object arguments (#165)
+* Fix `id_part` setup (#164)
+* Disable `id_part` for create command and subcommand (#163)
+* Support array index auto generate (#162)
+* Support to modify argument options for subcommand (#161)
+* Support subcommand generation (#154)
+* Add FAQs for Swagger definition (#160)
+* Fix `x-ms-skip-url-encoding` unparsed in Swagger (#159)
+
 0.15.1
 ++++++
 * Fix `workspace` bug on class argument unwrap (#155)

--- a/src/aaz_dev/utils/config.py
+++ b/src/aaz_dev/utils/config.py
@@ -4,7 +4,7 @@ from packaging import version
 
 class Config:
 
-    MIN_CLI_CORE_VERSION = version.parse("2.42.0")
+    MIN_CLI_CORE_VERSION = version.parse("2.43.0")
 
     AAZ_PATH = os.environ.get("AAZ_PATH", None)
     SWAGGER_PATH = os.environ.get("AAZ_SWAGGER_PATH", None)

--- a/version.py
+++ b/version.py
@@ -1,5 +1,5 @@
 
-_MAJOR, _MINOR, _PATCH, _SUFFIX = ("0", "15", "1", "")
+_MAJOR, _MINOR, _PATCH, _SUFFIX = ("0", "16", "0", "")
 
 # _PATCH: On main and in a nightly release the patch should be one ahead of the last released build.
 # _SUFFIX: This is mainly for nightly builds which have the suffix ".dev$DATE". See


### PR DESCRIPTION
- Support build-in keywords in property name generation (#167)
- Add portal CLI generator (#153)
- Support to generate property name starts with digit (#166)
- Support to modify default for array, dict and object arguments (#165)
- Fix `id_part` setup (#164)
- Disable `id_part` for create command and subcommand (#163)
- Support array index auto generate (#162)
- Support to modify argument options for subcommand (#161)
- Support subcommand generation (#154)
- Add FAQs for Swagger definition (#160)
- Fix `x-ms-skip-url-encoding` unparsed in Swagger (#159)