### PR TITLE
Release v0.17.0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,15 @@
 
 Release History
 ===============
+0.17.0
+++++++
+* Workspace swagger picker supports load default swagger module and resource providers (#175)
+* `aaz-dev run`: Add `--swagger-module-path`, "--module", "--resource-provider" to specify single swagger repo for code generation (#175)
+* `aaz-dev command-model generate-from-swagger`: Support generate command model from swagger by readme tag for pipeline use (#176)
+* `aaz-dev cli generate-by-swagger-tag`: Support generate code in cli from command models by using readme tag for pipeline use (#178)
+* `aaz-dev regenerate`: Support to regenerate aaz commands from command models (#178)
+* Fix Workspace display no arguments command error (#177)
+* Ignore '/' character in x-ms-identifiers swagger property (#174)
 
 0.16.2
 ++++++

--- a/version.py
+++ b/version.py
@@ -1,5 +1,5 @@
 
-_MAJOR, _MINOR, _PATCH, _SUFFIX = ("0", "16", "2", "")
+_MAJOR, _MINOR, _PATCH, _SUFFIX = ("0", "17", "0", "")
 
 # _PATCH: On main and in a nightly release the patch should be one ahead of the last released build.
 # _SUFFIX: This is mainly for nightly builds which have the suffix ".dev$DATE". See


### PR DESCRIPTION
0.17.0
----

* Workspace swagger picker supports load default swagger module and resource providers (#175)
* `aaz-dev run`: Add `--swagger-module-path`, "--module", "--resource-provider" to specify single swagger repo for code generation (#175)
* `aaz-dev command-model generate-from-swagger`: Support generate command model from swagger by readme tag for pipeline use (#176)
* `aaz-dev cli generate-by-swagger-tag`: Support generate code in cli from command models by using readme tag for pipeline use (#178)
* `aaz-dev regenerate`: Support to regenerate aaz commands from command models (#178)
* Fix Workspace display no arguments command error (#177)
* Ignore '/' character in x-ms-identifiers swagger property (#174)
