### PR TITLE
update requirements to support Python 3.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
-schematics~=2.1.0
+schematics~=2.1.1
 pyyaml~=5.4.0
 pytest~=6.2.0
 fuzzywuzzy~=0.18.0
-inflect~=5.3.0
+inflect~=6.0.2
 msrestazure~=0.6.4
-lxml~=4.6.4
-flask~=2.0.2
+lxml~=4.9.2
+flask~=2.1.3
 cachelib~=0.5.0
 xmltodict~=0.12.0
 packaging~=21.3


### PR DESCRIPTION
azure-cli does not support [python 3.11](https://github.com/Azure/azure-cli/issues/24494), update requirements first.