### PR TITLE
Release v0.19.0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,14 @@
 Release History
 ===============
 
+0.19.0
+++++++
+* Feature support subcommand modification inheritance (#184)
+* Fix _iter_schema_in_json when js has not schema (#185)
+* Update requirements to support Python 3.11 (#186)
+* Inherent subresource commands in aaz when export workspace (#187)
+* Support partial commands generation in a module (#189)
+
 0.18.0
 ++++++
 * Relink command after class unwrapped (#182)

--- a/src/aaz_dev/utils/config.py
+++ b/src/aaz_dev/utils/config.py
@@ -5,7 +5,7 @@ from .plane import PlaneEnum
 
 class Config:
 
-    MIN_CLI_CORE_VERSION = version.parse("2.44.0")
+    MIN_CLI_CORE_VERSION = version.parse("2.44.1")
 
     AAZ_PATH = os.environ.get("AAZ_PATH", None)
     SWAGGER_PATH = os.environ.get("AAZ_SWAGGER_PATH", None)

--- a/version.py
+++ b/version.py
@@ -1,5 +1,5 @@
 
-_MAJOR, _MINOR, _PATCH, _SUFFIX = ("0", "18", "0", "")
+_MAJOR, _MINOR, _PATCH, _SUFFIX = ("0", "19", "0", "")
 
 # _PATCH: On main and in a nightly release the patch should be one ahead of the last released build.
 # _SUFFIX: This is mainly for nightly builds which have the suffix ".dev$DATE". See


### PR DESCRIPTION
* Feature support subcommand modification inheritance (#184)
* Fix _iter_schema_in_json when js has not schema (#185)
* Update requirements to support Python 3.11 (#186)
* Inherent subresource commands in aaz when export workspace (#187)
* Support partial commands generation in a module (#189)