### PR TITLE
Release v0.19.3

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.19.3
+++++++
+* Support default error format for mgmt-plane API (#202)
+
 0.19.2
 ++++++
 * Support resource id filtered by request path in swagger picker (#198)

--- a/version.py
+++ b/version.py
@@ -1,5 +1,5 @@
 
-_MAJOR, _MINOR, _PATCH, _SUFFIX = ("0", "19", "2", "")
+_MAJOR, _MINOR, _PATCH, _SUFFIX = ("0", "19", "3", "")
 
 # _PATCH: On main and in a nightly release the patch should be one ahead of the last released build.
 # _SUFFIX: This is mainly for nightly builds which have the suffix ".dev$DATE". See


### PR DESCRIPTION
0.19.3
++++++
* Support default error format for mgmt-plane API (#202)