### PR TITLE
Release v0.20.0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,14 @@
 Release History
 ===============
 
+0.20.0
+++++++
+* Fix incorrect statement when checking for content in --cli-path and --cli-extension-path (#205)
+* Fix bug when merge sub resources in aaz (#206)
+* Support inherent argument hide property on flatten (#207)
+* Fix bug for string type output commands (#209)
+* Fix sub command inherit bugs (#211)
+
 0.19.3
 ++++++
 * Support default error format for mgmt-plane API (#202)

--- a/version.py
+++ b/version.py
@@ -1,5 +1,5 @@
 
-_MAJOR, _MINOR, _PATCH, _SUFFIX = ("0", "19", "3", "")
+_MAJOR, _MINOR, _PATCH, _SUFFIX = ("0", "20", "0", "")
 
 # _PATCH: On main and in a nightly release the patch should be one ahead of the last released build.
 # _SUFFIX: This is mainly for nightly builds which have the suffix ".dev$DATE". See


### PR DESCRIPTION
* Fix incorrect statement when checking for content in --cli-path and --cli-extension-path (#205)
* Fix bug when merge sub resources in aaz (#206)
* Support inherent argument hide property on flatten (#207)
* Fix bug for string type output commands (#209)
* Fix sub command inherit bugs (#211)