### PR TITLE
Add `title` field support for parameter in swagger.

### DIFF
--- a/src/aaz_dev/swagger/model/schema/parameter.py
+++ b/src/aaz_dev/swagger/model/schema/parameter.py
@@ -30,6 +30,7 @@ class ParameterBase(Model):
     name = StringType(
         required=True)  # The name of the parameter. Parameter names are case sensitive. If in is "path", the name field MUST correspond to the associated path segment from the path field in the Paths Object. See Path Templating for further information. For all other cases, the name corresponds to the parameter name used based on the in property.
     description = StringType()  # A brief description of the parameter. This could contain examples of use.
+    title = StringType()
     required = BooleanType(
         default=False)  # Determines whether this parameter is mandatory. If the parameter is in "path", this property is required and its value MUST be true. Otherwise, the property MAY be included and its default value is false.
     _in = StringType(


### PR DESCRIPTION
Fix bug when loading swagger resource which has no description for path parameters.

![image](https://github.com/Azure/aaz-dev-tools/assets/69238381/1dcd84e9-7bde-41f7-90d2-45a16aa8b835)
