### PR TITLE
Fix bug when special characters appreared in discription value

### DIFF
--- a/src/aaz_dev/cli/controller/az_operation_generator.py
+++ b/src/aaz_dev/cli/controller/az_operation_generator.py
@@ -799,7 +799,8 @@ def _iter_request_scopes_by_schema_base(schema, name, scope_define, arg_key, cmd
     for disc in discriminators:
         key_name = disc.property
         key_value = disc.value
-        disc_name = f"disc_{to_snack_case(disc.value)}"
+        disc_name = f"disc_{to_snack_case(disc.get_safe_value())}"
+
         disc_scope_define = scope_define + "{" + key_name + ":" + key_value + "}"
         disc_arg_key = arg_key
         for scopes in _iter_request_scopes_by_schema_base(disc, disc_name, disc_scope_define, disc_arg_key, cmd_ctx):
@@ -879,7 +880,7 @@ def _iter_response_scopes_by_schema_base(schema, name, scope_define, cmd_ctx):
     for disc in discriminators:
         key_name = to_snack_case(disc.property)
         key_value = disc.value
-        disc_name = f"disc_{to_snack_case(disc.value)}"
+        disc_name = f"disc_{to_snack_case(disc.get_safe_value())}"
 
         disc_scope_define = f'{scope_define}.discriminate_by("{key_name}", "{key_value}")'
         for scopes in _iter_response_scopes_by_schema_base(disc, disc_name, disc_scope_define, cmd_ctx):

--- a/src/aaz_dev/command/controller/cfg_reader.py
+++ b/src/aaz_dev/command/controller/cfg_reader.py
@@ -699,7 +699,7 @@ class CfgReader:
 
             elif schema.discriminators:
                 for disc in schema.discriminators:
-                    if current_idx == disc.value:
+                    if current_idx == disc.get_safe_value():
                         if not remain_idx:
                             return disc
                         return cls.find_sub_schema(disc, remain_idx)
@@ -716,7 +716,7 @@ class CfgReader:
 
             elif schema.discriminators:
                 for disc in schema.discriminators:
-                    if current_idx == disc.value:
+                    if current_idx == disc.get_safe_value():
                         if not remain_idx:
                             return disc
                         return cls.find_sub_schema(disc, remain_idx)
@@ -934,7 +934,7 @@ class CfgReader:
                 for disc in parent.discriminators:
                     for sub_parent, sub_schema, sub_schema_idx in cls._iter_sub_schema(disc, schema_filter):
                         if sub_schema:
-                            sub_schema_idx = [disc.value, *sub_schema_idx]
+                            sub_schema_idx = [disc.get_safe_value(), *sub_schema_idx]
                         yield sub_parent, sub_schema, sub_schema_idx
 
         elif isinstance(parent, CMDObjectSchemaDiscriminator):
@@ -956,7 +956,7 @@ class CfgReader:
                 for disc in parent.discriminators:
                     for sub_parent, sub_schema, sub_schema_idx in cls._iter_sub_schema(disc, schema_filter):
                         if sub_schema:
-                            sub_schema_idx = [disc.value, *sub_schema_idx]
+                            sub_schema_idx = [disc.get_safe_value(), *sub_schema_idx]
                         yield sub_parent, sub_schema, sub_schema_idx
 
         elif isinstance(parent, CMDArraySchemaBase):

--- a/src/aaz_dev/command/controller/workspace_cfg_editor.py
+++ b/src/aaz_dev/command/controller/workspace_cfg_editor.py
@@ -1412,7 +1412,7 @@ class WorkspaceCfgEditor(CfgReader):
 
         if schema.discriminators:
             for disc in schema.discriminators:
-                if disc.value == current_idx:
+                if disc.get_safe_value() == current_idx:
                     index.discriminator = cls._build_object_index_discriminator(disc, remain_idx, **kwargs)
                     break
 
@@ -1519,7 +1519,7 @@ class WorkspaceCfgEditor(CfgReader):
 
         if schema.discriminators:
             for disc in schema.discriminators:
-                if disc.value == current_idx:
+                if disc.get_safe_value() == current_idx:
                     index.discriminator = cls._build_object_index_discriminator(disc, remain_idx, **kwargs)
                     break
 

--- a/src/aaz_dev/command/model/configuration/_arg_builder.py
+++ b/src/aaz_dev/command/model/configuration/_arg_builder.py
@@ -42,7 +42,7 @@ class CMDArgBuilder:
                     if not arg_var.endswith("$"):
                         arg_var += '.'
                     if isinstance(schema, CMDObjectSchemaDiscriminator):
-                        arg_var += f'{schema.value}'
+                        arg_var += schema.get_safe_value()
                     elif isinstance(schema, CMDSchema):
                         arg_var += f'{schema.name}'.replace('$', '')  # some schema name may contain $
                     else:
@@ -302,7 +302,7 @@ class CMDArgBuilder:
             return [*self._ref_arg.options]
 
         if isinstance(self.schema, CMDObjectSchemaDiscriminator):
-            opt_name = self._build_option_name(self.schema.value)
+            opt_name = self._build_option_name(self.schema.get_safe_value())
         elif isinstance(self.schema, CMDSchema):
             name = self.schema.name.replace('$', '')
             if name == "[Index]" or name == "{Key}":

--- a/src/aaz_dev/command/model/configuration/_schema.py
+++ b/src/aaz_dev/command/model/configuration/_schema.py
@@ -34,7 +34,7 @@ from ._utils import CMDDiffLevelEnum
 from utils import exceptions
 
 import logging
-
+import re
 
 logger = logging.getLogger('backend')
 
@@ -781,6 +781,11 @@ class CMDObjectSchemaDiscriminator(Model):
                 disc.reformat(**kwargs)
             self.discriminators = sorted(self.discriminators, key=lambda disc: disc.value)
 
+    def get_safe_value(self):
+        """Some value may contain special characters such as Microsoft.db/mysql, it will cause issues. This function will replase them by `_`
+        """
+        safe_value = re.sub(r'[^A-Za-z0-9_-]', '_', self.value)
+        return safe_value
 
 # additionalProperties
 class CMDObjectSchemaAdditionalProperties(Model):


### PR DESCRIPTION
Support discriminator value which contains special characters like [Microsoft.Compute/virtualMachines](https://github.com/Azure/azure-rest-api-specs/blob/d247207c59848d06facf8a7b4f884e356205c15c/specification/resourcemover/resource-manager/Microsoft.Migrate/stable/2022-08-01/resourcemovercollection.json#L1933)