### PR TITLE
Support configuration key

### DIFF
--- a/src/aaz_dev/cli/controller/az_arg_group_generator.py
+++ b/src/aaz_dev/cli/controller/az_arg_group_generator.py
@@ -242,6 +242,9 @@ def render_arg(arg, cmd_ctx, arg_group=None):
     if arg.default:
         arg_kwargs["default"] = arg.default.value
 
+    if arg.configuration_key:
+        arg_kwargs["configured_default"] = arg.configuration_key
+
     arg_type, arg_kwargs, cls_builder_name = render_arg_base(arg, cmd_ctx, arg_kwargs)
 
     if arg.prompt:

--- a/src/aaz_dev/command/controller/specs_manager.py
+++ b/src/aaz_dev/command/controller/specs_manager.py
@@ -42,9 +42,12 @@ class AAZSpecsManager:
         if not os.path.isfile(tree_path):
             raise ValueError(f"Invalid Command Tree file path, expect a file: {tree_path}")
 
-        with open(tree_path, 'r') as f:
-            data = json.load(f)
-            self.tree = CMDSpecsCommandTree(data)
+        try:
+            with open(tree_path, 'r') as f:
+                data = json.load(f)
+                self.tree = CMDSpecsCommandTree(data)
+        except json.decoder.JSONDecodeError as e:
+            raise ValueError(f"Invalid Command Tree file: {tree_path}") from e
 
     # Commands folder
     def get_tree_file_path(self):

--- a/src/aaz_dev/command/controller/workspace_cfg_editor.py
+++ b/src/aaz_dev/command/controller/workspace_cfg_editor.py
@@ -286,6 +286,8 @@ class WorkspaceCfgEditor(CfgReader):
                 arg.default = None
             else:
                 arg.default = CMDArgDefault(kwargs['default'])
+        if 'configurationKey' in kwargs:
+            arg.configuration_key = kwargs['configurationKey']
         if 'prompt' in kwargs:
             if kwargs['prompt'] is None:
                 arg.prompt = None

--- a/src/aaz_dev/command/model/configuration/_arg.py
+++ b/src/aaz_dev/command/model/configuration/_arg.py
@@ -212,6 +212,10 @@ class CMDArg(CMDArgBase):
     # properties as nodes
     help = ModelType(CMDArgumentHelp)
     default = ModelType(CMDArgDefault)  # default value is used when argument isn't in command
+    configuration_key = StringType(
+        serialized_name='configurationKey',
+        deserialize_from='configurationKey',
+    )  # the key to retrieve the default value from cli configuration
     prompt = ModelType(CMDArgPromptInput)
 
     def __init__(self, *args, **kwargs):
@@ -239,6 +243,7 @@ class CMDArg(CMDArgBase):
 
         arg.required = builder.get_required()
         arg.default = builder.get_default()
+        arg.configuration_key = builder.get_configuration_key()
         arg.prompt = builder.get_prompt()
         arg.hide = builder.get_hide()
         return arg

--- a/src/aaz_dev/command/model/configuration/_arg_builder.py
+++ b/src/aaz_dev/command/model/configuration/_arg_builder.py
@@ -249,6 +249,11 @@ class CMDArgBuilder:
             return CMDArgDefault.build_default(self, self.schema.default)
         return None
 
+    def get_configuration_key(self):
+        if self._ref_arg:
+            return self._ref_arg.configuration_key
+        return None
+
     def get_prompt(self):
         if self._ref_arg:
             # ref_arg already has prompt return it

--- a/src/web/src/views/workspace/WSEditorCommandArgumentsContent.tsx
+++ b/src/web/src/views/workspace/WSEditorCommandArgumentsContent.tsx
@@ -609,7 +609,7 @@ function ArgumentReviewer(props: {
                 <Box sx={{ flexGrow: 1 }} />
                 {props.arg.required && <ArgRequiredTypography>[Required]</ArgRequiredTypography>}
             </Box>
-            {(props.arg.default !== undefined || choices.length > 0) && <Box
+            {(props.arg.default !== undefined || choices.length > 0 || props.arg.configurationKey !== undefined) && <Box
                 sx={{
                     ml: 5,
                     mt: 0.5,
@@ -622,6 +622,10 @@ function ArgumentReviewer(props: {
                 </ArgChoicesTypography>}
                 {props.arg.default !== undefined && <ArgChoicesTypography sx={{ ml: 1 }}>
                     {`Default: ${getDefaultValueToString()}`}
+                </ArgChoicesTypography>
+                }
+                {props.arg.configurationKey !== undefined && <ArgChoicesTypography sx={{ ml: 1 }}>
+                    {`ConfigurationKey: ${props.arg.configurationKey}`}
                 </ArgChoicesTypography>
                 }
             </Box>}
@@ -659,6 +663,7 @@ function ArgumentDialog(props: {
     const [hasPrompt, setHasPrompt] = useState<boolean | undefined>(false);
     const [promptMsg, setPromptMsg] = useState<string | undefined>(undefined);
     const [promptConfirm, setPromptConfirm] = useState<boolean | undefined>(undefined);
+    const [configurationKey, setConfigurationKey] = useState<string>("");
 
     const handleClose = () => {
         setInvalidText(undefined);
@@ -672,6 +677,7 @@ function ArgumentDialog(props: {
         let sHelp = shortHelp.trim();
         let lHelp = longHelp.trim();
         let gName = group.trim();
+        let cfgKey = configurationKey.trim();
 
         const names = name.split(' ').filter(n => n.length > 0);
         const sNames = sName?.split(' ').filter(n => n.length > 0) ?? undefined;
@@ -707,6 +713,11 @@ function ArgumentDialog(props: {
         let lines: string[] | null = null;
         if (lHelp.length > 1) {
             lines = lHelp.split('\n').filter(l => l.length > 0);
+        }
+
+        let argCfgKey: string | null = null;
+        if (cfgKey.length > 0) {
+            argCfgKey = cfgKey;
         }
 
         let argDefault = undefined;
@@ -775,6 +786,7 @@ function ArgumentDialog(props: {
             },
             default: argDefault,
             prompt: argPrompt,
+            configurationKey: argCfgKey,
         }
     }
 
@@ -912,6 +924,7 @@ function ArgumentDialog(props: {
         setHide(props.arg.hide);
         setShortHelp(props.arg.help?.short ?? "");
         setLongHelp(props.arg.help?.lines?.join("\n") ?? "");
+        setConfigurationKey(props.arg.configurationKey ?? "");
         setUpdating(false);
         setArgSimilarTree(undefined);
         setArgSimilarTreeExpandedIds([]);
@@ -1042,6 +1055,7 @@ function ArgumentDialog(props: {
                             />
                         </Box>
                     </>}
+
                     {hasPrompt !== undefined && <>
                         <InputLabel shrink sx={{ font: "inherit" }}>Prompt Input</InputLabel>
                         <Box sx={{
@@ -1096,6 +1110,19 @@ function ArgumentDialog(props: {
                             </Box>
                         </Box>
                     </>}
+                    <TextField
+                        id="configurationKey"
+                        label="Configuration Key"
+                        helperText="The key to retrieve the default value from cli Configuration"
+                        type='text'
+                        fullWidth
+                        variant='standard'
+                        value={configurationKey}
+                        onChange={(event: any) => {
+                            setConfigurationKey(event.target.value);
+                        }}
+                        margin="normal"
+                    />
 
                     <TextField
                         id="shortSummary"
@@ -1759,6 +1786,7 @@ interface CMDArg extends CMDArgBase {
     default?: CMDArgDefault<any>
     idPart?: string
     prompt?: CMDArgPromptInput
+    configurationKey?: string
 }
 
 interface CMDArgBaseT<T> extends CMDArgBase {
@@ -2141,6 +2169,7 @@ function decodeArg(response: any): { arg: CMDArg, clsDefineMap: ClsArgDefinition
         help: help,
         idPart: response.idPart,
         prompt: prompt,
+        configurationKey: response.configurationKey,
     }
 
     switch (argBase.type) {


### PR DESCRIPTION
Support set configuration key in argument, which is used to retrieve default value from cli configurations.

Related change in azure-cli-core: https://github.com/Azure/azure-cli/pull/27205