### PR TITLE
Support to pass an empty request body when it's required.

### DIFF
--- a/src/aaz_dev/swagger/model/schema/parameter.py
+++ b/src/aaz_dev/swagger/model/schema/parameter.py
@@ -196,6 +196,10 @@ class BodyParameter(ParameterBase, Linkable):
     def to_cmd(self, builder, **kwargs):
         v = builder(self.schema, in_base=False, support_cls_schema=True)
         v.name = self.name
+        if self.required:
+            # A required body parameter cannot be frozen.
+            # This can help to create an empty payload.
+            v.frozen = False
         if v.frozen:
             logger.warning(
                 msg=f"Request Body Parameter is None: {self.traces}"


### PR DESCRIPTION
For some APIs, the body parameter is **required** but all its properties are **read only**. Like this [swagger parameter](https://github.com/Azure/azure-rest-api-specs/blob/efbe157d69f1909baf2b866cc82df8e0093f533b/specification/vmware/resource-manager/Microsoft.AVS/stable/2023-03-01/vmware.json#L1450-L1458). In that case, we still need to pass an **empty** JSON object.

![image](https://github.com/Azure/aaz-dev-tools/assets/69238381/f0e9b7f4-a1dd-45aa-b20b-9047dcf1383a)
