### PR TITLE
data plane of plane enum supports resource-provider

### DIFF
--- a/src/aaz_dev/cli/api/_cmds.py
+++ b/src/aaz_dev/cli/api/_cmds.py
@@ -157,6 +157,7 @@ def generate_by_swagger_tag(profile, swagger_tag, extension_or_module_name, cli_
                 })
 
             v = v_list[0]
+            # TODO: handle plane here
             cfg_reader = aaz_specs.load_resource_cfg_reader(Config.DEFAULT_PLANE, resource_id, v)
             if not cfg_reader:
                 logger.error(f"Command models not exist in aaz for resource: {resource_id} version: {v}")

--- a/src/aaz_dev/command/api/editor.py
+++ b/src/aaz_dev/command/api/editor.py
@@ -15,7 +15,7 @@ def editor_workspaces():
         # create a new workspace
         # the name of workspace is required
         data = request.get_json()
-        if not data or not isinstance(data, dict) or 'name' not in data or 'plane' not in data:
+        if not data or not isinstance(data, dict) or 'name' not in data or 'plane' not in data or 'modNames' not in data or 'resourceProvider' not in data:
             raise exceptions.InvalidAPIUsage("Invalid request body")
         name = data['name']
         plane = data['plane']

--- a/src/aaz_dev/command/api/specs.py
+++ b/src/aaz_dev/command/api/specs.py
@@ -113,22 +113,19 @@ def filter_resources(plane):
 # planes
 @bp.route("/Planes", methods=("Get", ))
 def list_planes():
-    result = [
-        {
-            "name": PlaneEnum.Mgmt,
-            **PlaneEnum._config[PlaneEnum.Mgmt],
-        },
-        # {
-        #     "name": PlaneEnum.Data,
-        #     **PlaneEnum._config[PlaneEnum.Data],
-        # }
-    ]
+    result = []
+    for name, items in PlaneEnum._config.items():
+        result.append({
+            "name": name,
+            **items,
+        })
     return jsonify(result)
 
 
-# TODO: this api is called when data plane workspaces export aaz model.
-# @bp.route("/Planes/" + PlaneEnum.Data +"/ResourceProviders/{name: rp_name}", method=("GET", "PUT"))
-# def data_plane_resource_provider_config(rp_name):
+# # TODO: this api is called when data plane workspaces export aaz model.
+# @bp.route("/Planes/" + PlaneEnum._Data +"/{name: resource_provider}", method=("GET", "PUT"))
+# def data_plane_resource_provider_config(resource_provider):
+#     plane = PlaneEnum.Data(resource_provider)
 #     if request.method == "GET":
 #         # Get Data Plane Resource Provider Configuration
 #         pass

--- a/src/aaz_dev/command/controller/cfg_reader.py
+++ b/src/aaz_dev/command/controller/cfg_reader.py
@@ -46,7 +46,6 @@ class CfgReader:
                 if swagger_resource_path_to_resource_id(http.path) != resource_id:
                     continue
                 methods.add(http.request.method.lower())
-                # if isinstance(op, CMDHttpOperation)
         return tuple(methods) or None
 
     def get_update_cmd(self, resource_id, subresource=None):

--- a/src/aaz_dev/command/controller/specs_manager.py
+++ b/src/aaz_dev/command/controller/specs_manager.py
@@ -6,6 +6,7 @@ import shutil
 from command.model.configuration import CMDConfiguration, CMDHelp, CMDCommandExample, XMLSerializer
 from utils.base64 import b64encode_str
 from utils.config import Config
+from utils.plane import PlaneEnum
 from command.model.specs import CMDSpecsCommandTree, CMDSpecsCommandGroup, CMDSpecsCommand, CMDSpecsCommandVersion, CMDSpecsResource
 from command.templates import get_templates
 from utils import exceptions
@@ -68,7 +69,15 @@ class AAZSpecsManager:
 
     # resources
     def get_resource_plane_folder(self, plane):
-        return os.path.join(self.resources_folder, plane)
+        if plane == PlaneEnum.Mgmt:
+            return os.path.join(self.resources_folder, plane)
+        elif PlaneEnum.is_data_plane(plane):
+            scope = PlaneEnum.get_data_plane_scope(plane)
+            if not scope:
+                raise ValueError(f"Invalid plane: Missing scope in data plane '{plane}'")
+            return os.path.join(self.resources_folder, plane, scope)
+        else:
+            raise ValueError(f"Invalid plane: '{plane}'")
 
     def get_resource_cfg_folder(self, plane, resource_id):
         path = self.get_resource_plane_folder(plane)

--- a/src/aaz_dev/command/controller/workspace_manager.py
+++ b/src/aaz_dev/command/controller/workspace_manager.py
@@ -10,6 +10,7 @@ from swagger.controller.specs_manager import SwaggerSpecsManager
 from swagger.utils.exceptions import InvalidSwaggerValueError
 from utils import exceptions
 from utils.config import Config
+from utils.plane import PlaneEnum
 from .specs_manager import AAZSpecsManager
 from .workspace_cfg_editor import WorkspaceCfgEditor
 from command.model.configuration import CMDHelp, CMDResource, CMDCommandExample, CMDArg, CMDCommand
@@ -46,6 +47,9 @@ class WorkspaceManager:
         if not manager.is_in_memory and os.path.exists(manager.path):
             raise exceptions.ResourceConflict(
                 f"Workspace conflict: Workspace json file path exists: {manager.path}")
+        if plane == PlaneEnum._Data:
+            # add resource provider as the scope for data plane
+            plane = PlaneEnum.Data(resource_provider)
         manager.ws = CMDEditorWorkspace({
             "name": name,
             "plane": plane,

--- a/src/aaz_dev/swagger/controller/specs_manager.py
+++ b/src/aaz_dev/swagger/controller/specs_manager.py
@@ -14,7 +14,7 @@ class SwaggerSpecsModuleManager:
         self._rps_catch = None
         self._resource_op_group_map_cache = {}
         self._resource_map_cache = {}
-        assert plane in PlaneEnum.choices(), f"Invalid plane: '{self.plane}'"
+        assert plane == PlaneEnum.Mgmt or PlaneEnum.is_data_plane(plane), f"Invalid plane: '{self.plane}'"
         assert isinstance(module, SwaggerModule), f"Invalid module type: '{type(module)}'"
 
     def get_resource_providers(self):
@@ -136,7 +136,7 @@ class SwaggerSpecsManager:
 
         if plane == PlaneEnum.Mgmt:
             modules = self.specs.get_mgmt_plane_modules(plane=plane)
-        elif plane == PlaneEnum.Data:
+        elif PlaneEnum.is_data_plane(plane):
             modules = self.specs.get_data_plane_modules(plane=plane)
         else:
             raise exceptions.InvalidAPIUsage(f"invalid plane name '{plane}'")
@@ -158,7 +158,7 @@ class SwaggerSpecsManager:
 
         if plane == PlaneEnum.Mgmt:
             module = self.specs.get_mgmt_plane_module(*mod_names, plane=plane)
-        elif plane == PlaneEnum.Data:
+        elif PlaneEnum.is_data_plane(plane):
             module = self.specs.get_data_plane_module(*mod_names, plane=plane)
         else:
             raise exceptions.InvalidAPIUsage(f"invalid plane name '{plane}'")

--- a/src/aaz_dev/swagger/model/specs/_swagger_specs.py
+++ b/src/aaz_dev/swagger/model/specs/_swagger_specs.py
@@ -133,7 +133,7 @@ class SingleModuleSwaggerSpecs:
 
         module_str = '/'.join([plane, *names])
         module = None
-        for m in self.get_mgmt_plane_modules(plane):
+        for m in self.get_data_plane_modules(plane):
             if str(m) == module_str:
                 module = m
                 break

--- a/src/aaz_dev/swagger/tests/api_tests/test_specs.py
+++ b/src/aaz_dev/swagger/tests/api_tests/test_specs.py
@@ -21,7 +21,7 @@ class SwaggerSpecsApiTestCase(SwaggerSpecsTestCase):
 
     def test_data_plane_modules(self):
         with self.app.test_client() as c:
-            rv = c.get(f'/Swagger/Specs/{PlaneEnum.Data}')
+            rv = c.get(f'/Swagger/Specs/{PlaneEnum._Data}')
             json_data = rv.get_json()
             assert rv.status_code == 200, rv.get_json()['message']
             assert len(json_data) > 0
@@ -49,7 +49,7 @@ class SwaggerSpecsApiTestCase(SwaggerSpecsTestCase):
 
     def test_data_plane_rp(self):
         with self.app.test_client() as c:
-            rv = c.get(f'/Swagger/Specs/{PlaneEnum.Data}')
+            rv = c.get(f'/Swagger/Specs/{PlaneEnum._Data}')
             json_data = rv.get_json()
             assert rv.status_code == 200, rv.get_json()['message']
             for module in json_data:
@@ -86,7 +86,7 @@ class SwaggerSpecsApiTestCase(SwaggerSpecsTestCase):
 
     def test_data_plane_resources(self):
         with self.app.test_client() as c:
-            rv = c.get(f'/Swagger/Specs/{PlaneEnum.Data}')
+            rv = c.get(f'/Swagger/Specs/{PlaneEnum._Data}')
             modules = rv.get_json()
             assert rv.status_code == 200, rv.get_json()['message']
             for module in modules:
@@ -125,7 +125,7 @@ class SwaggerSpecsApiTestCase(SwaggerSpecsTestCase):
 
     def test_data_plane_resource_version(self):
         with self.app.test_client() as c:
-            rv = c.get(f'/Swagger/Specs/{PlaneEnum.Data}')
+            rv = c.get(f'/Swagger/Specs/{PlaneEnum._Data}')
             modules = rv.get_json()
             assert rv.status_code == 200, rv.get_json()['message']
             for module in modules:
@@ -171,7 +171,7 @@ class SwaggerSpecsApiTestCase(SwaggerSpecsTestCase):
 
     def test_data_plane_resource_and_version_in_module(self):
         with self.app.test_client() as c:
-            rv = c.get(f'/Swagger/Specs/{PlaneEnum.Data}')
+            rv = c.get(f'/Swagger/Specs/{PlaneEnum._Data}')
             modules = rv.get_json()
             assert rv.status_code == 200, rv.get_json()['message']
             for module in modules:

--- a/src/aaz_dev/swagger/tests/common.py
+++ b/src/aaz_dev/swagger/tests/common.py
@@ -15,7 +15,7 @@ class SwaggerSpecsTestCase(ApiTestCase):
         self.specs = SwaggerSpecs(folder_path=folder_path)
 
     def get_data_plane_modules(self, module_filter=None):
-        for module in self.specs.get_data_plane_modules(PlaneEnum.Data):
+        for module in self.specs.get_data_plane_modules(PlaneEnum._Data):
             if module_filter is None or module_filter(module):
                 yield module
 

--- a/src/aaz_dev/utils/fields.py
+++ b/src/aaz_dev/utils/fields.py
@@ -6,7 +6,7 @@ class PlaneField(StringType):
 
     def __init__(self, *args, **kwargs):
         super(PlaneField, self).__init__(
-            choices=PlaneEnum.choices(),
+            regex=r'^({})|({}:[a-z0-9_\-.]+)$'.format(PlaneEnum.Mgmt, PlaneEnum._Data),
             *args, **kwargs
         )
 

--- a/src/aaz_dev/utils/plane.py
+++ b/src/aaz_dev/utils/plane.py
@@ -1,35 +1,63 @@
 
 
+def create_data_plane_name(resource_provider):
+    return 'data-plane:' + resource_provider.lower()
+
+
 class PlaneEnum:
     Mgmt = "mgmt-plane"
-    Data = "data-plane"
+    _Data = "data-plane"
+
+    @staticmethod
+    def Data(resource_provider):
+        """For data plane, it's required to provide resource_provider which defined the scope of data plane."""
+        return create_data_plane_name(resource_provider)
 
     _config = {
         Mgmt: {
             "displayName": "Control plane",
             "client": "MgmtClient",  # MgmtClient is implemented in azure.cli.core.aaz._client
         },
-        Data: {
+        # the general data-plane configuration
+        _Data: {
             "displayName": "Data plane",
             # DataPlaneClient is implemented as the default client for data plane using AAD Auth
-            "client": "DataPlaneClient",
-        }
+            "client": "DataClient",
+        },
+        # example for special data plane configuration
+        # create_data_plane_name("Microsoft.Insights"): {
+        #     "displayName": "Data plane for Microsoft.Insights",
+        #     "client": "InsightDataClient",
+        #     "swagger_modules": ["monitor"],
+        # }
     }
 
     @classmethod
-    def choices(cls):
-        return tuple(v for k, v in vars(cls).items() if not k.startswith('_') and isinstance(v, str))
-
-    @classmethod
     def is_valid_swagger_module(cls, plane, module_name):
-        swagger_modules = cls._config[plane].get('swagger_modules', None)
+        swagger_modules = cls._config.get(plane, {}).get('swagger_modules', None)
         if not swagger_modules or module_name in swagger_modules:
             return True
         return False
+    
+    @classmethod
+    def is_data_plane(cls, plane):
+        return plane.split(":")[0] == cls._Data
+    
+    @classmethod
+    def get_data_plane_scope(cls, plane):
+        if not cls.is_data_plane(plane) or plane == cls._Data:
+            return None
+        return plane.replace(cls._Data + ':', '') or None
 
     @classmethod
     def http_client(cls, plane):
-        return cls._config[plane]['client']
+        if plane in cls._config:
+            return cls._config[plane]['client']
+        elif cls.is_data_plane(plane):
+            # use the default data plane client
+            return cls._config[cls._Data]['client']
+        else:
+            raise ValueError(f"Invalid plane name '{plane}'")
 
 
 __all__ = ["PlaneEnum"]

--- a/src/web/src/views/workspace/WorkspaceSelector.tsx
+++ b/src/web/src/views/workspace/WorkspaceSelector.tsx
@@ -1,4 +1,4 @@
-import { Autocomplete, createFilterOptions, Dialog, DialogActions, DialogContent, DialogTitle, TextField, Button, InputLabel, LinearProgress, Alert } from '@mui/material';
+import { Autocomplete, createFilterOptions, Dialog, DialogActions, DialogContent, DialogTitle, TextField, Button, InputLabel, Alert } from '@mui/material';
 import { Box } from '@mui/system';
 import axios from 'axios';
 import * as React from 'react';
@@ -281,7 +281,7 @@ class WorkspaceCreateDialog extends React.Component<WorkspaceCreateDialogProps, 
 
     loadSwaggerModules = async (plane: Plane | null) => {
         if (plane !== null) {
-            if (plane!.moduleOptions?.length ?? 0 > 0) {
+            if (plane!.moduleOptions?.length) {
                 this.setState({
                     moduleOptions: plane!.moduleOptions!,
                     moduleOptionsCommonPrefix: `/Swagger/Specs/${plane!.name}/`,


### PR DESCRIPTION
A valid data-plane should be in the `data-plane:resource-provider-name` format.

The data-plane of different resource-providers have different client configurations. So we need to add the resource-provider name to limit the scope of client configurations for the aaz models.  