### PR TITLE
set specific encoding for all platforms

### DIFF
--- a/src/aaz_dev/cli/controller/az_module_manager.py
+++ b/src/aaz_dev/cli/controller/az_module_manager.py
@@ -82,7 +82,7 @@ class AzModuleManager:
             generator.save()
         for patch_file, file_data in self._patch_module(mod_name):
             os.makedirs(os.path.dirname(patch_file), exist_ok=True)
-            with open(patch_file, 'w') as f:
+            with open(patch_file, 'w', encoding="utf-8") as f:
                 f.write(file_data)
         module = CLIModule()
         module.name = mod_name
@@ -99,7 +99,7 @@ class AzModuleManager:
         if not os.path.exists(file) or not os.path.isfile(file):
             raise exceptions.InvalidAPIUsage(f"Patch Module failed: Cannot find file: {file}")
 
-        with open(file, 'r') as f:
+        with open(file, 'r', encoding="utf-8") as f:
             lines = f.read().split('\n')
 
         start_line = None
@@ -205,7 +205,7 @@ class AzModuleManager:
 
         register_info_lines = None
         find_command_group = False
-        with open(cmd_group_file, 'r') as f:
+        with open(cmd_group_file, 'r', encoding="utf-8") as f:
             while f.readable():
                 line = f.readline()
                 if line.startswith('@register_command_group('):
@@ -232,7 +232,7 @@ class AzModuleManager:
         aaz_info_lines = None
         find_command = False
         is_wait_command = False
-        with open(path, 'r') as f:
+        with open(path, 'r', encoding="utf-8") as f:
             while f.readable():
                 line = f.readline()
                 if line.startswith('@register_command('):
@@ -406,7 +406,7 @@ class AzMainManager(AzModuleManager):
         # written files
         for path, data in new_files.items():
             os.makedirs(os.path.dirname(path), exist_ok=True)
-            with open(path, 'w') as f:
+            with open(path, 'w', encoding="utf-8") as f:
                 f.write(data)
 
         module = CLIModule()
@@ -510,7 +510,7 @@ class AzExtensionManager(AzModuleManager):
         ext_path = self.get_mod_ext_path(mod_name)
         metadata_path = os.path.join(ext_path, 'azext_metadata.json')
         if os.path.exists(metadata_path):
-            with open(metadata_path, 'r') as f:
+            with open(metadata_path, 'r', encoding="utf-8") as f:
                 metadata = json.load(f)
             if "azext.minCliCoreVersion" not in metadata or \
                     version.parse(metadata["azext.minCliCoreVersion"]) < Config.MIN_CLI_CORE_VERSION:
@@ -525,7 +525,7 @@ class AzExtensionManager(AzModuleManager):
     def update_module(self, mod_name, profiles, **kwargs):
         module = super().update_module(mod_name, profiles, **kwargs)
         file_path, ext_metadata = self.create_or_update_mod_azext_metadata(mod_name)
-        with open(file_path, 'w') as f:
+        with open(file_path, 'w', encoding="utf-8") as f:
             f.write(json.dumps(ext_metadata, indent=4, sort_keys=True))
         return module
 
@@ -651,7 +651,7 @@ class AzExtensionManager(AzModuleManager):
         # written files
         for path, data in new_files.items():
             os.makedirs(os.path.dirname(path), exist_ok=True)
-            with open(path, 'w') as f:
+            with open(path, 'w', encoding="utf-8") as f:
                 f.write(data)
 
         module = CLIModule()

--- a/src/aaz_dev/cli/controller/az_profile_generator.py
+++ b/src/aaz_dev/cli/controller/az_profile_generator.py
@@ -62,7 +62,7 @@ class AzProfileGenerator:
                 pass
         for path, data in self._modified_files.items():
             os.makedirs(os.path.dirname(path), exist_ok=True)
-            with open(path, 'w') as f:
+            with open(path, 'w', encoding="utf-8") as f:
                 f.write(data)
         self._removed_folders = set()
         self._removed_files = set()

--- a/src/aaz_dev/cli/controller/portal_cli_generator.py
+++ b/src/aaz_dev/cli/controller/portal_cli_generator.py
@@ -304,7 +304,7 @@ class PortalCliGenerator:
                 if not self.valid_portal_json_format(resource_info):
                     logging.info("json format error")
                     continue
-                with open(resource_file_path, "w") as f_out:
+                with open(resource_file_path, "w", encoding="utf-8") as f_out:
                     f_out.write(json.dumps(resource_info, indent=4))
 
     def generate_cmds_portal_file(self, cmd_portal_list):

--- a/src/aaz_dev/command/api/_cmds.py
+++ b/src/aaz_dev/command/api/_cmds.py
@@ -164,7 +164,7 @@ def generate_command_models_from_swagger(swagger_tag, workspace_path=None):
 )
 def verify():
     def verify_command(file_path, node):
-        with open(file_path, "r") as fp:
+        with open(file_path, "r", encoding="utf-8") as fp:
             content = fp.read()
 
         paths = re.findall(r"]\(([^)]+)\)", content)

--- a/src/aaz_dev/command/controller/specs_manager.py
+++ b/src/aaz_dev/command/controller/specs_manager.py
@@ -43,7 +43,7 @@ class AAZSpecsManager:
             raise ValueError(f"Invalid Command Tree file path, expect a file: {tree_path}")
 
         try:
-            with open(tree_path, 'r') as f:
+            with open(tree_path, 'r', encoding="utf-8") as f:
                 data = json.load(f)
                 self.tree = CMDSpecsCommandTree(data)
         except json.decoder.JSONDecodeError as e:
@@ -158,7 +158,7 @@ class AAZSpecsManager:
             if not os.path.exists(ref_path):
                 return None
             json_path = None
-            with open(ref_path, 'r') as f:
+            with open(ref_path, 'r', encoding="utf-8") as f:
                 for line in f.readlines():
                     match = self.REFERENCE_LINE.fullmatch(line)
                     if match:
@@ -175,19 +175,19 @@ class AAZSpecsManager:
             # Not recommend to use xml, because there are some issues in XMLSerializer
             if not os.path.isfile(xml_path):
                 raise ValueError(f"Invalid file path: {xml_path}")
-            with open(xml_path, 'r') as f:
+            with open(xml_path, 'r', encoding="utf-8") as f:
                 cfg = XMLSerializer.from_xml(CMDConfiguration, f.read())
             data = self.render_resource_cfg_to_json(cfg)
-            with open(json_path, 'w') as f:
+            with open(json_path, 'w', encoding="utf-8") as f:
                 f.write(data)
             data = self.render_resource_cfg_to_xml(cfg)
-            with open(xml_path, 'w') as f:
+            with open(xml_path, 'w', encoding="utf-8") as f:
                 f.write(data)
 
         if not os.path.isfile(json_path):
             raise ValueError(f"Invalid file path: {json_path}")
 
-        with open(json_path, 'r') as f:
+        with open(json_path, 'r', encoding="utf-8") as f:
             #print(json_path)
             data = json.load(f)
         cfg = CMDConfiguration(data)
@@ -514,7 +514,7 @@ class AAZSpecsManager:
 
         for file_path, data in update_files.items():
             os.makedirs(os.path.dirname(file_path), exist_ok=True)
-            with open(file_path, 'w') as f:
+            with open(file_path, 'w', encoding="utf-8") as f:
                 f.write(data)
 
         self._modified_command_groups = set()

--- a/src/aaz_dev/command/controller/workspace_cfg_editor.py
+++ b/src/aaz_dev/command/controller/workspace_cfg_editor.py
@@ -34,12 +34,12 @@ class WorkspaceCfgEditor(CfgReader):
     @classmethod
     def load_resource(cls, ws_folder, resource_id, version):
         path = cls.get_cfg_path(ws_folder, resource_id)
-        with open(path, 'r') as f:
+        with open(path, 'r', encoding="utf-8") as f:
             data = json.load(f)
         if '$ref' in data:
             ref_resource_id = data['$ref']
             path = cls.get_cfg_path(ws_folder, ref_resource_id)
-            with open(path, 'r') as f:
+            with open(path, 'r', encoding="utf-8") as f:
                 data = json.load(f)
         cfg = CMDConfiguration(data)
         for resource in cfg.resources:

--- a/src/aaz_dev/command/controller/workspace_manager.py
+++ b/src/aaz_dev/command/controller/workspace_manager.py
@@ -109,7 +109,7 @@ class WorkspaceManager:
         if not os.path.exists(self.path) or not os.path.isfile(self.path):
             raise exceptions.ResourceNotFind(
                 f"Workspace json file not exist: {self.path}")
-        with open(self.path, 'r') as f:
+        with open(self.path, 'r', encoding="utf-8") as f:
             data = json.load(f)
             self.ws = CMDEditorWorkspace(raw_data=data)
 
@@ -173,7 +173,7 @@ class WorkspaceManager:
         # verify ws timestamps
         # TODO: add write lock for path file
         if os.path.exists(self.path):
-            with open(self.path, 'r') as f:
+            with open(self.path, 'r', encoding="utf-8") as f:
                 data = json.load(f)
                 pre_ws = CMDEditorWorkspace(data)
             if pre_ws.version != self.ws.version:
@@ -181,7 +181,7 @@ class WorkspaceManager:
                     f"Workspace Changed after: {self.ws.version}")
 
         self.ws.version = datetime.utcnow()
-        with open(self.path, 'w') as f:
+        with open(self.path, 'w', encoding="utf-8") as f:
             data = json.dumps(self.ws.to_primitive(), ensure_ascii=False)
             f.write(data)
 
@@ -190,7 +190,7 @@ class WorkspaceManager:
 
         for file_name, data in update_files:
             os.makedirs(os.path.dirname(file_name), exist_ok=True)
-            with open(file_name, 'w') as f:
+            with open(file_name, 'w', encoding="utf-8") as f:
                 f.write(data)
 
         self._cfg_editors = {}


### PR DESCRIPTION
For *nix os, utf8 is default system encoding which is used when python open func is working without a given encoding format.

However, windows may use local systems encoding which might be incompatible with non-ascii characters in files. 

Set encoding in file operations can avoid this error.

![image](https://github.com/Azure/aaz-dev-tools/assets/8137253/05804cc6-16a2-4b98-a889-34922c81b6a7)
