### PR TITLE
Release v2.2.0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,11 @@
 Release History
 ===============
 
+2.2.0
+++++++
+* Add `aaz-dev swagger export-resources` command. (#302)
+* Set `utf-8` encoding for all file open. (#298)
+
 2.1.0
 ++++++
 * Support empty object defined in Swagger specification. (#293)

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -36,7 +36,7 @@ github:
 pypi: https://pypi.org/project/aaz-dev/
 
 # TODO: get version number from github
-version: v2.1.0
+version: v2.2.0
 
 # Build settings
 theme: minima

--- a/version.py
+++ b/version.py
@@ -1,5 +1,5 @@
 
-_MAJOR, _MINOR, _PATCH, _SUFFIX = ("2", "1", "0", "")
+_MAJOR, _MINOR, _PATCH, _SUFFIX = ("2", "2", "0", "")
 
 # _PATCH: On main and in a nightly release the patch should be one ahead of the last released build.
 # _SUFFIX: This is mainly for nightly builds which have the suffix ".dev$DATE". See


### PR DESCRIPTION
2.2.0
++++++
* Add `aaz-dev swagger export-resources` command. (#302)
* Set `utf-8` encoding for all file open. (#298)