### PR TITLE
Fix bug in swagger retrieve. Frozen discriminators only when the discriminator key of property is frozen.

### DIFF
--- a/src/aaz_dev/swagger/model/schema/schema.py
+++ b/src/aaz_dev/swagger/model/schema/schema.py
@@ -490,7 +490,7 @@ class Schema(Model, Linkable):
 
                     v = builder(disc_child, in_base=True, support_cls_schema=False)
                     assert isinstance(v, CMDObjectSchemaBase)
-                    if v.frozen:
+                    if v.frozen and prop_dict[disc_prop].frozen:
                         disc.frozen = True
                     if v.props:
                         disc.props = [prop for prop in v.props if prop.name not in prop_dict]


### PR DESCRIPTION
The properties of Some discriminators may all read-only. So in create/update command, they will be frozen. But the discriminator key is usually writable in the request. If we drop those frozen discriminators, the discriminator will lose some available values to assign. In this PR, the discriminators only frozen when the discriminator key is frozen.