### PR TITLE
release v2.5.0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,13 @@
 Release History
 ===============
 
+2.5.0
+++++++
+* Ignore `--subscription` generation when it has alias (#318)
+* Fix data-plane generation issue (#317)
+* Fix bug to render dynamic endpoint client (#314)
+* Add documentation for data-plane dynamic endpoint config (#315)
+
 2.4.0
 ++++++
 * Support data plane client with dynamic endpoint fetched from a response. (#311)

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -36,7 +36,7 @@ github:
 pypi: https://pypi.org/project/aaz-dev/
 
 # TODO: get version number from github
-version: v2.4.0
+version: v2.5.0
 
 # Build settings
 theme: minima

--- a/src/aaz_dev/utils/config.py
+++ b/src/aaz_dev/utils/config.py
@@ -5,7 +5,7 @@ from .plane import PlaneEnum
 
 class Config:
 
-    MIN_CLI_CORE_VERSION = version.parse("2.54.0")
+    MIN_CLI_CORE_VERSION = version.parse("2.55.0")
 
     AAZ_PATH = os.environ.get("AAZ_PATH", None)
     SWAGGER_PATH = os.environ.get("AAZ_SWAGGER_PATH", None)

--- a/version.py
+++ b/version.py
@@ -1,5 +1,5 @@
 
-_MAJOR, _MINOR, _PATCH, _SUFFIX = ("2", "4", "0", "")
+_MAJOR, _MINOR, _PATCH, _SUFFIX = ("2", "5", "0", "")
 
 # _PATCH: On main and in a nightly release the patch should be one ahead of the last released build.
 # _SUFFIX: This is mainly for nightly builds which have the suffix ".dev$DATE". See


### PR DESCRIPTION
2.5.0
++++++
* Ignore `--subscription` generation when it has alias (#318)
* Fix data-plane generation issue (#317)
* Fix bug to render dynamic endpoint client (#314)
* Add documentation for data-plane dynamic endpoint config (#315)
