### PR TITLE
adapt new polices for lro operation

### DIFF
--- a/src/aaz_dev/swagger/model/schema/cmd_builder.py
+++ b/src/aaz_dev/swagger/model/schema/cmd_builder.py
@@ -584,14 +584,13 @@ class CMDBuilder:
 
         success_codes = reduce(lambda x, y: x | y, [codes for codes, _ in success_responses])
         if schema.x_ms_long_running_operation and not success_codes & {200, 201}:
-            if lro_schema := schema.x_ms_lro_final_state_schema:
-                lro_response = Response()
-                lro_response.description = "Response schema for long-running operation."
-                lro_response.schema = lro_schema
+            lro_response = Response()
+            lro_response.description = "Response schema for long-running operation."
 
-                success_responses.append(({200, 201}, lro_response))  # use `final-state-schema` as response
-            else:
-                logger.warning(f"No response schema for long-running-operation: {schema.operation_id}.")
+            if lro_schema := schema.x_ms_lro_final_state_schema:
+                lro_response.schema = lro_schema  # use `final-state-schema` as response
+
+            success_responses.append(({200, 201}, lro_response))
 
         # # default response
         # if 'default' not in error_responses and len(error_responses) == 1:


### PR DESCRIPTION
Fix: https://github.com/Azure/aaz-dev-tools/issues/331

from https://github.com/Azure/azure-openapi-validator/blob/main/docs/delete-response-codes.md#output-message
> long-running (LRO) delete operations must have 202, 204, and default responses. They must not have any other responses.

But we still have 200 response from `operationStatuses`. The schema for `operationStatues` is not defined by the swagger, we need to adapt that.