### PR TITLE
Fix readOnly parse problem in swagger

### DIFF
--- a/src/aaz_dev/swagger/model/schema/cmd_builder.py
+++ b/src/aaz_dev/swagger/model/schema/cmd_builder.py
@@ -251,6 +251,7 @@ class CMDBuilder:
                 model._type = f"@{name}"
             else:
                 model = self(schema.ref_instance, **kwargs)
+                model.read_only = self.read_only
             return model
 
         if name not in self.cls_definitions:
@@ -258,6 +259,7 @@ class CMDBuilder:
                 # register in cls_definitions first in case of loop reference below
                 self.cls_definitions[name] = {"count": 1}
                 model = self(schema.ref_instance, **kwargs)
+                model.read_only = self.read_only
                 if isinstance(model, (CMDObjectSchemaBase, CMDArraySchemaBase)):
                     # Important: only support object and array schema to defined as cls
                     # when self.cls_definitions[name]['count'] > 1, the loop reference exist
@@ -266,6 +268,7 @@ class CMDBuilder:
                     del self.cls_definitions[name]
             else:
                 model = self(schema.ref_instance, **kwargs)
+                model.read_only = self.read_only
         else:
             if support_cls_schema:
                 self.cls_definitions[name]['count'] += 1
@@ -291,6 +294,7 @@ class CMDBuilder:
                         value=name
                     )
                 model = self(schema.ref_instance, **kwargs)
+                model.read_only = self.read_only
         return model
 
     def get_cls_definition_model(self, model):

--- a/src/aaz_dev/swagger/model/schema/schema.py
+++ b/src/aaz_dev/swagger/model/schema/schema.py
@@ -90,6 +90,9 @@ class ReferenceSchema(Model, Linkable):
             self.ref_instance.link(swagger_loader, *instance_traces)
         if self.ref_instance.x_ms_azure_resource:
             self.x_ms_azure_resource = True
+        if self.ref_instance.read_only:
+            # inherit read only from $ref
+            self.read_only = True
 
     def to_cmd(self, builder, support_cls_schema=False, **kwargs):
         model = builder.register_cls_definition(self, support_cls_schema=support_cls_schema, **kwargs)
@@ -295,6 +298,8 @@ class Schema(Model, Linkable):
                 self.ref_instance.link(swagger_loader, *instance_traces)
             if self.ref_instance.x_ms_azure_resource:
                 self.x_ms_azure_resource = True
+            if self.ref_instance.read_only:
+                self.read_only = True
 
         if self.items is not None:
             if isinstance(self.items, list):


### PR DESCRIPTION
The readOnly property can be defined in both schema and it's reference. This PR fixed the readOnly problem recognize for schema like this https://github.com/Azure/azure-rest-api-specs/blob/13962fb6f539de6125f94cdfdf177bfcd24efcb4/specification/apicenter/resource-manager/Microsoft.ApiCenter/preview/2024-03-15-preview/apicenter.json#L3649-L3653