### PR TITLE
Show `ParseJsonFailed` error logs when failed to parse swagger json file

### DIFF
--- a/src/aaz_dev/swagger/model/specs/_resource_provider.py
+++ b/src/aaz_dev/swagger/model/specs/_resource_provider.py
@@ -183,8 +183,12 @@ class ResourceProvider:
     def _parse_resources_in_file(self, file_path):
         resources = []
 
-        with open(file_path, 'r', encoding='utf-8') as f:
-            body = json.load(f)
+        try:
+            with open(file_path, 'r', encoding='utf-8') as f:
+                body = json.load(f)
+        except Exception as err:
+            logger.error(f'InvalidSwaggerFile: {self} : ParseJsonFailed: {file_path} : {err}')
+            return resources
 
         # check swagger version
         swagger_version = body.get('swagger', None)

--- a/src/aaz_dev/swagger/model/specs/_swagger_loader.py
+++ b/src/aaz_dev/swagger/model/specs/_swagger_loader.py
@@ -21,8 +21,12 @@ class SwaggerLoader:
         if loaded is not None:
             return loaded
 
-        with open(file_path, 'r', encoding='utf-8') as f:
-            body = json.load(f)
+        try:
+            with open(file_path, 'r', encoding='utf-8') as f:
+                body = json.load(f)
+        except Exception as err:
+            logger.error(f'InvalidSwaggerFile: ParseJsonFailed: {file_path} : {err}')
+            raise
 
         if 'example' in file_path.lower():
             loaded = body


### PR DESCRIPTION
![image](https://github.com/Azure/aaz-dev-tools/assets/69238381/4c8b2d9c-0743-48c6-874b-6bed6a045f6a)
