### PR TITLE
Escape backslashes in docstrings

### DIFF
--- a/src/aaz_dev/cli/templates/aaz/command/_cmd.py.j2
+++ b/src/aaz_dev/cli/templates/aaz/command/_cmd.py.j2
@@ -34,10 +34,10 @@ class {{ leaf.cls_name }}(
         AAZCommand
     {%- endif -%}
 ):
-    """{{ leaf.help.short }}
+    """{{ leaf.help.short|replace('\\', '\\\\') }}
     {%- if leaf.help.long is not none and leaf.help.long|length %}
 
-    {{ leaf.help.long.split('\n')|join('\n    ') }}
+    {{ leaf.help.long.split('\n')|join('\n    ')|replace('\\', '\\\\') }}
     {%- endif %}
     {%- if leaf.help.examples is not none and leaf.help.examples|length %}
     {%- for example in leaf.help.examples %}

--- a/src/aaz_dev/cli/templates/aaz/group/__cmd_group.py.j2
+++ b/src/aaz_dev/cli/templates/aaz/group/__cmd_group.py.j2
@@ -22,10 +22,10 @@ from azure.cli.core.aaz import *
 )
 {%- endif %}
 class __CMDGroup(AAZCommandGroup):
-    """{{ node.help.short }}
+    """{{ node.help.short|replace('\\', '\\\\') }}
     {%- if node.help.long is not none and node.help.long|length %}
 
-    {{ node.help.long.split('\n')|join('\n    ') }}
+    {{ node.help.long.split('\n')|join('\n    ')|replace('\\', '\\\\') }}
     {%- endif %}
     """
     pass


### PR DESCRIPTION
Python 3.12 gives a `SyntaxWarning: invalid escape sequence` when it sees an unescaped backslash.

More context:


Azure/autorest.python#2560
Azure/autorest.python#2551