### PR TITLE
use keywords as argument name

### DIFF
--- a/src/aaz_dev/cli/templates/_filters.py
+++ b/src/aaz_dev/cli/templates/_filters.py
@@ -68,10 +68,10 @@ def get_prop(env, data):
 
 
 @pass_environment
-def get_scope(env, data):
+def avoid_conflict(env, data):
     def convert(data):
         if data in _PYTHON_BUILD_IN_KEYWORDS:
-            return f"{data}_"
+            return f"{data}_"  # pep 8: used by convention to avoid conflicts
 
         return data
 
@@ -88,5 +88,5 @@ custom_filters = {
     "is_stable": is_stable,
     "constant_convert": constant_convert,
     "get_prop": get_prop,
-    "get_scope": get_scope
+    "avoid_conflict": avoid_conflict
 }

--- a/src/aaz_dev/cli/templates/_filters.py
+++ b/src/aaz_dev/cli/templates/_filters.py
@@ -86,7 +86,7 @@ def handle_keyword(env, data):
 
     data = data.split(".")
 
-    return data[0] + "".join(get_prop(env, i) for i in data[1:])
+    return data[0] + "".join(get_prop(env, i) for i in data[1:])  # keyword in response, x.else.x -> x["else"].x
 
 
 custom_filters = {

--- a/src/aaz_dev/cli/templates/_filters.py
+++ b/src/aaz_dev/cli/templates/_filters.py
@@ -67,6 +67,19 @@ def get_prop(env, data):
         return f'.{data}'
 
 
+@pass_environment
+def get_scope(env, data):
+    def convert(data):
+        if data in _PYTHON_BUILD_IN_KEYWORDS:
+            return f"{data}_"
+
+        return data
+
+    assert isinstance(data, str)
+
+    return ".".join(convert(i) for i in data.split("."))
+
+
 custom_filters = {
     "camel_case": camel_case,
     "snake_case": snake_case,
@@ -74,5 +87,6 @@ custom_filters = {
     "is_preview": is_preview,
     "is_stable": is_stable,
     "constant_convert": constant_convert,
-    "get_prop": get_prop
+    "get_prop": get_prop,
+    "get_scope": get_scope
 }

--- a/src/aaz_dev/cli/templates/_filters.py
+++ b/src/aaz_dev/cli/templates/_filters.py
@@ -80,6 +80,15 @@ def avoid_conflict(env, data):
     return ".".join(convert(i) for i in data.split("."))
 
 
+@pass_environment
+def handle_keyword(env, data):
+    assert isinstance(data, str)
+
+    data = data.split(".")
+
+    return data[0] + "".join(get_prop(env, i) for i in data[1:])
+
+
 custom_filters = {
     "camel_case": camel_case,
     "snake_case": snake_case,
@@ -88,5 +97,6 @@ custom_filters = {
     "is_stable": is_stable,
     "constant_convert": constant_convert,
     "get_prop": get_prop,
-    "avoid_conflict": avoid_conflict
+    "avoid_conflict": avoid_conflict,
+    "handle_keyword": handle_keyword,
 }

--- a/src/aaz_dev/cli/templates/aaz/command/_cmd.py.j2
+++ b/src/aaz_dev/cli/templates/aaz/command/_cmd.py.j2
@@ -103,10 +103,10 @@ class {{ leaf.cls_name }}(
         # define Arg Group "{{ arg_group.name }}"
         {%- for scope, scope_define, arguments in arg_group.iter_scopes() %}
 
-        {{ scope }} = {{ scope_define }}
+        {{ scope|get_scope }} = {{ scope_define|get_scope }}
 
         {%- for arg_name, arg_type, arg_kwargs, cls_builder_name in arguments %}
-        {{ scope }}.{{ arg_name }} = {{ arg_type }}(
+        {{ scope|get_scope }}.{{ arg_name|get_scope }} = {{ arg_type }}(
         {%- if not arg_kwargs|length %})
         {%- else %}
             {%- for key, value in arg_kwargs.items() %}
@@ -129,7 +129,7 @@ class {{ leaf.cls_name }}(
         )
         {%- endif %}
         {%- if cls_builder_name is not none %}
-        cls.{{ cls_builder_name }}({{ scope }}.{{ arg_name }})
+        cls.{{ cls_builder_name }}({{ scope|get_scope }}.{{ arg_name|get_scope }})
         {%- endif %}
 
         {%- endfor %}
@@ -171,10 +171,10 @@ class {{ leaf.cls_name }}(
 
         {%- for scope, scope_define, arguments in arg_cls.iter_scopes() %}
 
-        {{ scope }} = {{ scope_define }}
+        {{ scope|get_scope }} = {{ scope_define|get_scope }}
 
         {%- for arg_name, arg_type, arg_kwargs, cls_builder_name in arguments %}
-        {{ scope }}.{{ arg_name }} = {{ arg_type }}(
+        {{ scope|get_scope }}.{{ arg_name|get_scope }} = {{ arg_type }}(
         {%- if not arg_kwargs|length %})
         {%- else %}
             {%- for key, value in arg_kwargs.items() %}
@@ -191,7 +191,7 @@ class {{ leaf.cls_name }}(
         )
         {%- endif %}
         {%- if cls_builder_name is not none %}
-        cls.{{ cls_builder_name }}({{ scope }}.{{ arg_name }})
+        cls.{{ cls_builder_name }}({{ scope|get_scope }}.{{ arg_name|get_scope }})
         {%- endif %}
         {%- endfor %}
 
@@ -293,7 +293,7 @@ class {{ leaf.cls_name }}(
             {%- for line in idx_lines %}
             {{line}}
             {%- endfor %}
-            {{ scope }} = {{ scope_define }}
+            {{ scope|get_scope }} = {{ scope_define|get_scope }}
 
             {%- if filter_builder is not none %}
             filters = {{ filter_builder }}
@@ -327,7 +327,7 @@ class {{ leaf.cls_name }}(
             {%- for line in idx_lines %}
             {{line}}
             {%- endfor %}
-            {{ scope }} = {{ scope_define }}
+            {{ scope|get_scope }} = {{ scope_define|get_scope }}
 
             {%- if filter_builder is not none %}
             filters = {{ filter_builder }}
@@ -510,8 +510,8 @@ class {{ leaf.cls_name }}(
 
             {%- if scope_define is not none %}
 
-            {{ scope }} = {{ op.content.BUILDER_NAME }}.get({{ scope_define|constant_convert }})
-            if {{ scope }} is not None:
+            {{ scope|get_scope }} = {{ op.content.BUILDER_NAME }}.get({{ scope_define|get_scope|constant_convert }})
+            if {{ scope|get_scope }} is not None:
             {%- endif %}
 
             {%- for prop_name, prop_type, is_const, const_value, arg_key, prop_type_kwargs, cls_builder_name in props %}
@@ -519,18 +519,18 @@ class {{ leaf.cls_name }}(
             {%- if cls_builder_name is not none %}{{ leaf.helper_cls_name }}.{{ cls_builder_name }}({% endif %}
             {%- if prop_name != '[]' and prop_name != '{}' -%}
             {%- if is_const -%}
-            {{ scope }}.set_const({{ prop_name|constant_convert }}, {{ const_value|constant_convert }}, {{ prop_type }}
+            {{ scope|get_scope }}.set_const({{ prop_name|constant_convert }}, {{ const_value|constant_convert }}, {{ prop_type }}
                 {%- if arg_key is not none %}, {{ arg_key|constant_convert }}{% endif %}
                 {%- if prop_type_kwargs is not none and prop_type_kwargs|length %}, typ_kwargs={{ prop_type_kwargs|constant_convert }}{% endif %})
             {%- else -%}
-            {{ scope }}.set_prop({{ prop_name|constant_convert }}, {{ prop_type }}
+            {{ scope|get_scope }}.set_prop({{ prop_name|constant_convert }}, {{ prop_type }}
                 {%- if arg_key is not none %}, {{ arg_key|constant_convert }}{% endif %}
                 {%- if prop_type_kwargs is not none and prop_type_kwargs|length %}, typ_kwargs={{ prop_type_kwargs|constant_convert }}{% endif %})
             {%- endif %}
             {%- elif prop_name == '{}' and prop_type is none -%}
-            {{ scope }}.set_anytype_elements({%- if arg_key is not none %}{{ arg_key|constant_convert }}{% endif %})
+            {{ scope|get_scope }}.set_anytype_elements({%- if arg_key is not none %}{{ arg_key|constant_convert }}{% endif %})
             {%- else -%}
-            {{ scope }}.set_elements({{ prop_type }}
+            {{ scope|get_scope }}.set_elements({{ prop_type }}
                 {%- if arg_key is not none %}, {{ arg_key|constant_convert }}{% endif %}
                 {%- if prop_type_kwargs is not none and prop_type_kwargs|length %}, typ_kwargs={{ prop_type_kwargs|constant_convert }}{% endif %})
             {%- endif %}
@@ -539,7 +539,7 @@ class {{ leaf.cls_name }}(
 
             {%- for disc_name, disc_value in discriminators %}
             {% if scope_define is not none %}{{ "    " }}{% endif -%}
-            {{ scope }}.discriminate_by({{ disc_name|constant_convert }}, {{ disc_value|constant_convert }})
+            {{ scope|get_scope }}.discriminate_by({{ disc_name|constant_convert }}, {{ disc_value|constant_convert }})
             {%- endfor %}
 
             {%- endfor %}
@@ -601,10 +601,10 @@ class {{ leaf.cls_name }}(
 
             {%- for scope, scope_define, props in response.schema.iter_scopes() %}
 
-            {{ scope }} = {{ scope_define }}
+            {{ scope|get_scope }} = {{ scope_define|get_scope }}
 
             {%- for prop_name, prop_type, prop_kwargs, cls_builder_name in props %}
-            {{ scope }}{{ prop_name|get_prop }} = {{ prop_type }}(
+            {{ scope|get_scope }}{{ prop_name|get_prop }} = {{ prop_type }}(
             {%- if not prop_kwargs|length %})
             {%- else %}
                 {%- for key, value in prop_kwargs.items() %}
@@ -613,7 +613,7 @@ class {{ leaf.cls_name }}(
             )
             {%- endif %}
             {%- if cls_builder_name is not none %}
-            {{ leaf.helper_cls_name }}.{{ cls_builder_name }}({{ scope }}{{ prop_name|get_prop }})
+            {{ leaf.helper_cls_name }}.{{ cls_builder_name }}({{ scope|get_scope }}{{ prop_name|get_prop }})
             {%- endif %}
             {%- endfor %}
 
@@ -672,8 +672,8 @@ class {{ leaf.cls_name }}(
 
             {%- if scope_define is not none %}
 
-            {{ scope }} = {{ op.BUILDER_NAME }}.get({{ scope_define|constant_convert }})
-            if {{ scope }} is not None:
+            {{ scope|get_scope }} = {{ op.BUILDER_NAME }}.get({{ scope_define|get_scope|constant_convert }})
+            if {{ scope|get_scope }} is not None:
             {%- endif %}
 
             {%- for prop_name, prop_type, is_const, const_value, arg_key, prop_type_kwargs, cls_builder_name in props %}
@@ -681,18 +681,18 @@ class {{ leaf.cls_name }}(
             {%- if cls_builder_name is not none %}{{ leaf.helper_cls_name }}.{{ cls_builder_name }}({% endif %}
             {%- if prop_name != '[]' and prop_name != '{}' -%}
             {%- if is_const -%}
-            {{ scope }}.set_const({{ prop_name|constant_convert }}, {{ const_value|constant_convert }}, {{ prop_type }}
+            {{ scope|get_scope }}.set_const({{ prop_name|constant_convert }}, {{ const_value|constant_convert }}, {{ prop_type }}
                 {%- if arg_key is not none %}, {{ arg_key|constant_convert }}{% endif %}
                 {%- if prop_type_kwargs is not none and prop_type_kwargs|length %}, typ_kwargs={{ prop_type_kwargs|constant_convert }}{% endif %})
             {%- else -%}
-            {{ scope }}.set_prop({{ prop_name|constant_convert }}, {{ prop_type }}
+            {{ scope|get_scope }}.set_prop({{ prop_name|constant_convert }}, {{ prop_type }}
                 {%- if arg_key is not none %}, {{ arg_key|constant_convert }}{% endif %}
                 {%- if prop_type_kwargs is not none and prop_type_kwargs|length %}, typ_kwargs={{ prop_type_kwargs|constant_convert }}{% endif %})
             {%- endif %}
             {%- elif prop_name == '{}' and prop_type is none -%}
-            {{ scope }}.set_anytype_elements({%- if arg_key is not none %}{{ arg_key|constant_convert }}{% endif %})
+            {{ scope|get_scope }}.set_anytype_elements({%- if arg_key is not none %}{{ arg_key|constant_convert }}{% endif %})
             {%- else -%}
-            {{ scope }}.set_elements({{ prop_type }}
+            {{ scope|get_scope }}.set_elements({{ prop_type }}
                 {%- if arg_key is not none %}, {{ arg_key|constant_convert }}{% endif %}
                 {%- if prop_type_kwargs is not none and prop_type_kwargs|length %}, typ_kwargs={{ prop_type_kwargs|constant_convert }}{% endif %})
             {%- endif %}
@@ -701,7 +701,7 @@ class {{ leaf.cls_name }}(
 
             {%- for disc_name, disc_value in discriminators %}
             {% if scope_define is not none %}{{ "    " }}{% endif -%}
-            {{ scope }}.discriminate_by({{ disc_name|constant_convert }}, {{ disc_value|constant_convert }})
+            {{ scope|get_scope }}.discriminate_by({{ disc_name|constant_convert }}, {{ disc_value|constant_convert }})
             {%- endfor %}
 
             {%- endfor %}
@@ -750,8 +750,8 @@ class {{ leaf.helper_cls_name }}:
 
         {%- if scope_define is not none %}
 
-        {{ scope }} = {{ update_cls.BUILDER_NAME }}.get({{ scope_define|constant_convert }})
-        if {{ scope }} is not None:
+        {{ scope|get_scope }} = {{ update_cls.BUILDER_NAME }}.get({{ scope_define|get_scope|constant_convert }})
+        if {{ scope|get_scope }} is not None:
         {%- endif %}
 
         {%- for prop_name, prop_type, is_const, const_value, arg_key, prop_type_kwargs, cls_builder_name in props %}
@@ -759,18 +759,18 @@ class {{ leaf.helper_cls_name }}:
         {%- if cls_builder_name is not none %}cls.{{ cls_builder_name }}({% endif %}
         {%- if prop_name != '[]' and prop_name != '{}' -%}
         {%- if is_const -%}
-        {{ scope }}.set_const({{ prop_name|constant_convert }}, {{ const_value|constant_convert }}, {{ prop_type }}
+        {{ scope|get_scope }}.set_const({{ prop_name|constant_convert }}, {{ const_value|constant_convert }}, {{ prop_type }}
             {%- if arg_key is not none %}, {{ arg_key|constant_convert }}{% endif %}
             {%- if prop_type_kwargs is not none and prop_type_kwargs|length %}, typ_kwargs={{ prop_type_kwargs|constant_convert }}{% endif %})
         {%- else -%}
-        {{ scope }}.set_prop({{ prop_name|constant_convert }}, {{ prop_type }}
+        {{ scope|get_scope }}.set_prop({{ prop_name|constant_convert }}, {{ prop_type }}
             {%- if arg_key is not none %}, {{ arg_key|constant_convert }}{% endif %}
             {%- if prop_type_kwargs is not none and prop_type_kwargs|length %}, typ_kwargs={{ prop_type_kwargs|constant_convert }}{% endif %})
         {%- endif %}
         {%- elif prop_name == '{}' and prop_type is none -%}
-        {{ scope }}.set_anytype_elements({%- if arg_key is not none %}{{ arg_key|constant_convert }}{% endif %})
+        {{ scope|get_scope }}.set_anytype_elements({%- if arg_key is not none %}{{ arg_key|constant_convert }}{% endif %})
         {%- else -%}
-        {{ scope }}.set_elements({{ prop_type }}
+        {{ scope|get_scope }}.set_elements({{ prop_type }}
             {%- if arg_key is not none %}, {{ arg_key|constant_convert }}{% endif %}
             {%- if prop_type_kwargs is not none and prop_type_kwargs|length %}, typ_kwargs={{ prop_type_kwargs|constant_convert }}{% endif %})
         {%- endif %}
@@ -779,7 +779,7 @@ class {{ leaf.helper_cls_name }}:
 
         {%- for disc_name, disc_value in discriminators %}
         {% if scope_define is not none %}{{ "    " }}{% endif -%}
-        {{ scope }}.discriminate_by({{ disc_name|constant_convert }}, {{ disc_value|constant_convert }})
+        {{ scope|get_scope }}.discriminate_by({{ disc_name|constant_convert }}, {{ disc_value|constant_convert }})
         {%- endfor %}
 
         {%- endfor %}
@@ -820,10 +820,10 @@ class {{ leaf.helper_cls_name }}:
 
         {%- for scope, scope_define, props in resp_cls.iter_scopes() %}
 
-        {{ scope }} = {{ scope_define }}
+        {{ scope|get_scope }} = {{ scope_define|get_scope }}
 
         {%- for prop_name, prop_type, prop_kwargs, cls_builder_name in props %}
-        {{ scope }}{{ prop_name|get_prop }} = {{ prop_type }}(
+        {{ scope|get_scope }}{{ prop_name|get_prop }} = {{ prop_type }}(
         {%- if not prop_kwargs|length %})
         {%- else %}
             {%- for key, value in prop_kwargs.items() %}
@@ -832,7 +832,7 @@ class {{ leaf.helper_cls_name }}:
         )
         {%- endif %}
         {%- if cls_builder_name is not none %}
-        cls.{{ cls_builder_name }}({{ scope }}{{ prop_name|get_prop }})
+        cls.{{ cls_builder_name }}({{ scope|get_scope }}{{ prop_name|get_prop }})
         {%- endif %}
         {%- endfor %}
 

--- a/src/aaz_dev/cli/templates/aaz/command/_cmd.py.j2
+++ b/src/aaz_dev/cli/templates/aaz/command/_cmd.py.j2
@@ -820,7 +820,7 @@ class {{ leaf.helper_cls_name }}:
 
         {%- for scope, scope_define, props in resp_cls.iter_scopes() %}
 
-        {{ scope|avoid_conflict }} = {{ scope_define|avoid_conflict }}
+        {{ scope|avoid_conflict }} = {{ scope_define|handle_keyword }}
 
         {%- for prop_name, prop_type, prop_kwargs, cls_builder_name in props %}
         {{ scope|avoid_conflict }}{{ prop_name|get_prop }} = {{ prop_type }}(

--- a/src/aaz_dev/cli/templates/aaz/command/_cmd.py.j2
+++ b/src/aaz_dev/cli/templates/aaz/command/_cmd.py.j2
@@ -103,10 +103,10 @@ class {{ leaf.cls_name }}(
         # define Arg Group "{{ arg_group.name }}"
         {%- for scope, scope_define, arguments in arg_group.iter_scopes() %}
 
-        {{ scope|get_scope }} = {{ scope_define|get_scope }}
+        {{ scope|avoid_conflict }} = {{ scope_define|avoid_conflict }}
 
         {%- for arg_name, arg_type, arg_kwargs, cls_builder_name in arguments %}
-        {{ scope|get_scope }}.{{ arg_name|get_scope }} = {{ arg_type }}(
+        {{ scope|avoid_conflict }}.{{ arg_name|avoid_conflict }} = {{ arg_type }}(
         {%- if not arg_kwargs|length %})
         {%- else %}
             {%- for key, value in arg_kwargs.items() %}
@@ -129,7 +129,7 @@ class {{ leaf.cls_name }}(
         )
         {%- endif %}
         {%- if cls_builder_name is not none %}
-        cls.{{ cls_builder_name }}({{ scope|get_scope }}.{{ arg_name|get_scope }})
+        cls.{{ cls_builder_name }}({{ scope|avoid_conflict }}.{{ arg_name|avoid_conflict }})
         {%- endif %}
 
         {%- endfor %}
@@ -171,10 +171,10 @@ class {{ leaf.cls_name }}(
 
         {%- for scope, scope_define, arguments in arg_cls.iter_scopes() %}
 
-        {{ scope|get_scope }} = {{ scope_define|get_scope }}
+        {{ scope|avoid_conflict }} = {{ scope_define|avoid_conflict }}
 
         {%- for arg_name, arg_type, arg_kwargs, cls_builder_name in arguments %}
-        {{ scope|get_scope }}.{{ arg_name|get_scope }} = {{ arg_type }}(
+        {{ scope|avoid_conflict }}.{{ arg_name|avoid_conflict }} = {{ arg_type }}(
         {%- if not arg_kwargs|length %})
         {%- else %}
             {%- for key, value in arg_kwargs.items() %}
@@ -191,7 +191,7 @@ class {{ leaf.cls_name }}(
         )
         {%- endif %}
         {%- if cls_builder_name is not none %}
-        cls.{{ cls_builder_name }}({{ scope|get_scope }}.{{ arg_name|get_scope }})
+        cls.{{ cls_builder_name }}({{ scope|avoid_conflict }}.{{ arg_name|avoid_conflict }})
         {%- endif %}
         {%- endfor %}
 
@@ -287,13 +287,13 @@ class {{ leaf.cls_name }}(
             {%- for line in idx_lines %}
             {{line}}
             {%- endfor %}
-            return {{ scope_define }}
+            return {{ scope_define|avoid_conflict }}
 
             {%- else %}
             {%- for line in idx_lines %}
             {{line}}
             {%- endfor %}
-            {{ scope|get_scope }} = {{ scope_define|get_scope }}
+            {{ scope|avoid_conflict }} = {{ scope_define|avoid_conflict }}
 
             {%- if filter_builder is not none %}
             filters = {{ filter_builder }}
@@ -320,14 +320,14 @@ class {{ leaf.cls_name }}(
             {%- for line in idx_lines %}
             {{line}}
             {%- endfor %}
-            {{ scope_define }} = value
+            {{ scope_define|avoid_conflict }} = value
             return
 
             {%- else %}
             {%- for line in idx_lines %}
             {{line}}
             {%- endfor %}
-            {{ scope|get_scope }} = {{ scope_define|get_scope }}
+            {{ scope|avoid_conflict }} = {{ scope_define|avoid_conflict }}
 
             {%- if filter_builder is not none %}
             filters = {{ filter_builder }}
@@ -510,8 +510,8 @@ class {{ leaf.cls_name }}(
 
             {%- if scope_define is not none %}
 
-            {{ scope|get_scope }} = {{ op.content.BUILDER_NAME }}.get({{ scope_define|get_scope|constant_convert }})
-            if {{ scope|get_scope }} is not None:
+            {{ scope|avoid_conflict }} = {{ op.content.BUILDER_NAME }}.get({{ scope_define|avoid_conflict|constant_convert }})
+            if {{ scope|avoid_conflict }} is not None:
             {%- endif %}
 
             {%- for prop_name, prop_type, is_const, const_value, arg_key, prop_type_kwargs, cls_builder_name in props %}
@@ -519,18 +519,18 @@ class {{ leaf.cls_name }}(
             {%- if cls_builder_name is not none %}{{ leaf.helper_cls_name }}.{{ cls_builder_name }}({% endif %}
             {%- if prop_name != '[]' and prop_name != '{}' -%}
             {%- if is_const -%}
-            {{ scope|get_scope }}.set_const({{ prop_name|constant_convert }}, {{ const_value|constant_convert }}, {{ prop_type }}
+            {{ scope|avoid_conflict }}.set_const({{ prop_name|constant_convert }}, {{ const_value|constant_convert }}, {{ prop_type }}
                 {%- if arg_key is not none %}, {{ arg_key|constant_convert }}{% endif %}
                 {%- if prop_type_kwargs is not none and prop_type_kwargs|length %}, typ_kwargs={{ prop_type_kwargs|constant_convert }}{% endif %})
             {%- else -%}
-            {{ scope|get_scope }}.set_prop({{ prop_name|constant_convert }}, {{ prop_type }}
+            {{ scope|avoid_conflict }}.set_prop({{ prop_name|constant_convert }}, {{ prop_type }}
                 {%- if arg_key is not none %}, {{ arg_key|constant_convert }}{% endif %}
                 {%- if prop_type_kwargs is not none and prop_type_kwargs|length %}, typ_kwargs={{ prop_type_kwargs|constant_convert }}{% endif %})
             {%- endif %}
             {%- elif prop_name == '{}' and prop_type is none -%}
-            {{ scope|get_scope }}.set_anytype_elements({%- if arg_key is not none %}{{ arg_key|constant_convert }}{% endif %})
+            {{ scope|avoid_conflict }}.set_anytype_elements({%- if arg_key is not none %}{{ arg_key|constant_convert }}{% endif %})
             {%- else -%}
-            {{ scope|get_scope }}.set_elements({{ prop_type }}
+            {{ scope|avoid_conflict }}.set_elements({{ prop_type }}
                 {%- if arg_key is not none %}, {{ arg_key|constant_convert }}{% endif %}
                 {%- if prop_type_kwargs is not none and prop_type_kwargs|length %}, typ_kwargs={{ prop_type_kwargs|constant_convert }}{% endif %})
             {%- endif %}
@@ -539,7 +539,7 @@ class {{ leaf.cls_name }}(
 
             {%- for disc_name, disc_value in discriminators %}
             {% if scope_define is not none %}{{ "    " }}{% endif -%}
-            {{ scope|get_scope }}.discriminate_by({{ disc_name|constant_convert }}, {{ disc_value|constant_convert }})
+            {{ scope|avoid_conflict }}.discriminate_by({{ disc_name|constant_convert }}, {{ disc_value|constant_convert }})
             {%- endfor %}
 
             {%- endfor %}
@@ -601,10 +601,10 @@ class {{ leaf.cls_name }}(
 
             {%- for scope, scope_define, props in response.schema.iter_scopes() %}
 
-            {{ scope|get_scope }} = {{ scope_define|get_scope }}
+            {{ scope|avoid_conflict }} = {{ scope_define|avoid_conflict }}
 
             {%- for prop_name, prop_type, prop_kwargs, cls_builder_name in props %}
-            {{ scope|get_scope }}{{ prop_name|get_prop }} = {{ prop_type }}(
+            {{ scope|avoid_conflict }}{{ prop_name|get_prop }} = {{ prop_type }}(
             {%- if not prop_kwargs|length %})
             {%- else %}
                 {%- for key, value in prop_kwargs.items() %}
@@ -613,7 +613,7 @@ class {{ leaf.cls_name }}(
             )
             {%- endif %}
             {%- if cls_builder_name is not none %}
-            {{ leaf.helper_cls_name }}.{{ cls_builder_name }}({{ scope|get_scope }}{{ prop_name|get_prop }})
+            {{ leaf.helper_cls_name }}.{{ cls_builder_name }}({{ scope|avoid_conflict }}{{ prop_name|get_prop }})
             {%- endif %}
             {%- endfor %}
 
@@ -672,8 +672,8 @@ class {{ leaf.cls_name }}(
 
             {%- if scope_define is not none %}
 
-            {{ scope|get_scope }} = {{ op.BUILDER_NAME }}.get({{ scope_define|get_scope|constant_convert }})
-            if {{ scope|get_scope }} is not None:
+            {{ scope|avoid_conflict }} = {{ op.BUILDER_NAME }}.get({{ scope_define|avoid_conflict|constant_convert }})
+            if {{ scope|avoid_conflict }} is not None:
             {%- endif %}
 
             {%- for prop_name, prop_type, is_const, const_value, arg_key, prop_type_kwargs, cls_builder_name in props %}
@@ -681,18 +681,18 @@ class {{ leaf.cls_name }}(
             {%- if cls_builder_name is not none %}{{ leaf.helper_cls_name }}.{{ cls_builder_name }}({% endif %}
             {%- if prop_name != '[]' and prop_name != '{}' -%}
             {%- if is_const -%}
-            {{ scope|get_scope }}.set_const({{ prop_name|constant_convert }}, {{ const_value|constant_convert }}, {{ prop_type }}
+            {{ scope|avoid_conflict }}.set_const({{ prop_name|constant_convert }}, {{ const_value|constant_convert }}, {{ prop_type }}
                 {%- if arg_key is not none %}, {{ arg_key|constant_convert }}{% endif %}
                 {%- if prop_type_kwargs is not none and prop_type_kwargs|length %}, typ_kwargs={{ prop_type_kwargs|constant_convert }}{% endif %})
             {%- else -%}
-            {{ scope|get_scope }}.set_prop({{ prop_name|constant_convert }}, {{ prop_type }}
+            {{ scope|avoid_conflict }}.set_prop({{ prop_name|constant_convert }}, {{ prop_type }}
                 {%- if arg_key is not none %}, {{ arg_key|constant_convert }}{% endif %}
                 {%- if prop_type_kwargs is not none and prop_type_kwargs|length %}, typ_kwargs={{ prop_type_kwargs|constant_convert }}{% endif %})
             {%- endif %}
             {%- elif prop_name == '{}' and prop_type is none -%}
-            {{ scope|get_scope }}.set_anytype_elements({%- if arg_key is not none %}{{ arg_key|constant_convert }}{% endif %})
+            {{ scope|avoid_conflict }}.set_anytype_elements({%- if arg_key is not none %}{{ arg_key|constant_convert }}{% endif %})
             {%- else -%}
-            {{ scope|get_scope }}.set_elements({{ prop_type }}
+            {{ scope|avoid_conflict }}.set_elements({{ prop_type }}
                 {%- if arg_key is not none %}, {{ arg_key|constant_convert }}{% endif %}
                 {%- if prop_type_kwargs is not none and prop_type_kwargs|length %}, typ_kwargs={{ prop_type_kwargs|constant_convert }}{% endif %})
             {%- endif %}
@@ -701,7 +701,7 @@ class {{ leaf.cls_name }}(
 
             {%- for disc_name, disc_value in discriminators %}
             {% if scope_define is not none %}{{ "    " }}{% endif -%}
-            {{ scope|get_scope }}.discriminate_by({{ disc_name|constant_convert }}, {{ disc_value|constant_convert }})
+            {{ scope|avoid_conflict }}.discriminate_by({{ disc_name|constant_convert }}, {{ disc_value|constant_convert }})
             {%- endfor %}
 
             {%- endfor %}
@@ -750,8 +750,8 @@ class {{ leaf.helper_cls_name }}:
 
         {%- if scope_define is not none %}
 
-        {{ scope|get_scope }} = {{ update_cls.BUILDER_NAME }}.get({{ scope_define|get_scope|constant_convert }})
-        if {{ scope|get_scope }} is not None:
+        {{ scope|avoid_conflict }} = {{ update_cls.BUILDER_NAME }}.get({{ scope_define|avoid_conflict|constant_convert }})
+        if {{ scope|avoid_conflict }} is not None:
         {%- endif %}
 
         {%- for prop_name, prop_type, is_const, const_value, arg_key, prop_type_kwargs, cls_builder_name in props %}
@@ -759,18 +759,18 @@ class {{ leaf.helper_cls_name }}:
         {%- if cls_builder_name is not none %}cls.{{ cls_builder_name }}({% endif %}
         {%- if prop_name != '[]' and prop_name != '{}' -%}
         {%- if is_const -%}
-        {{ scope|get_scope }}.set_const({{ prop_name|constant_convert }}, {{ const_value|constant_convert }}, {{ prop_type }}
+        {{ scope|avoid_conflict }}.set_const({{ prop_name|constant_convert }}, {{ const_value|constant_convert }}, {{ prop_type }}
             {%- if arg_key is not none %}, {{ arg_key|constant_convert }}{% endif %}
             {%- if prop_type_kwargs is not none and prop_type_kwargs|length %}, typ_kwargs={{ prop_type_kwargs|constant_convert }}{% endif %})
         {%- else -%}
-        {{ scope|get_scope }}.set_prop({{ prop_name|constant_convert }}, {{ prop_type }}
+        {{ scope|avoid_conflict }}.set_prop({{ prop_name|constant_convert }}, {{ prop_type }}
             {%- if arg_key is not none %}, {{ arg_key|constant_convert }}{% endif %}
             {%- if prop_type_kwargs is not none and prop_type_kwargs|length %}, typ_kwargs={{ prop_type_kwargs|constant_convert }}{% endif %})
         {%- endif %}
         {%- elif prop_name == '{}' and prop_type is none -%}
-        {{ scope|get_scope }}.set_anytype_elements({%- if arg_key is not none %}{{ arg_key|constant_convert }}{% endif %})
+        {{ scope|avoid_conflict }}.set_anytype_elements({%- if arg_key is not none %}{{ arg_key|constant_convert }}{% endif %})
         {%- else -%}
-        {{ scope|get_scope }}.set_elements({{ prop_type }}
+        {{ scope|avoid_conflict }}.set_elements({{ prop_type }}
             {%- if arg_key is not none %}, {{ arg_key|constant_convert }}{% endif %}
             {%- if prop_type_kwargs is not none and prop_type_kwargs|length %}, typ_kwargs={{ prop_type_kwargs|constant_convert }}{% endif %})
         {%- endif %}
@@ -779,7 +779,7 @@ class {{ leaf.helper_cls_name }}:
 
         {%- for disc_name, disc_value in discriminators %}
         {% if scope_define is not none %}{{ "    " }}{% endif -%}
-        {{ scope|get_scope }}.discriminate_by({{ disc_name|constant_convert }}, {{ disc_value|constant_convert }})
+        {{ scope|avoid_conflict }}.discriminate_by({{ disc_name|constant_convert }}, {{ disc_value|constant_convert }})
         {%- endfor %}
 
         {%- endfor %}
@@ -820,10 +820,10 @@ class {{ leaf.helper_cls_name }}:
 
         {%- for scope, scope_define, props in resp_cls.iter_scopes() %}
 
-        {{ scope|get_scope }} = {{ scope_define|get_scope }}
+        {{ scope|avoid_conflict }} = {{ scope_define|avoid_conflict }}
 
         {%- for prop_name, prop_type, prop_kwargs, cls_builder_name in props %}
-        {{ scope|get_scope }}{{ prop_name|get_prop }} = {{ prop_type }}(
+        {{ scope|avoid_conflict }}{{ prop_name|get_prop }} = {{ prop_type }}(
         {%- if not prop_kwargs|length %})
         {%- else %}
             {%- for key, value in prop_kwargs.items() %}
@@ -832,7 +832,7 @@ class {{ leaf.helper_cls_name }}:
         )
         {%- endif %}
         {%- if cls_builder_name is not none %}
-        cls.{{ cls_builder_name }}({{ scope|get_scope }}{{ prop_name|get_prop }})
+        cls.{{ cls_builder_name }}({{ scope|avoid_conflict }}{{ prop_name|get_prop }})
         {%- endif %}
         {%- endfor %}
 

--- a/src/aaz_dev/cli/templates/aaz/command/_cmd.py.j2
+++ b/src/aaz_dev/cli/templates/aaz/command/_cmd.py.j2
@@ -601,7 +601,7 @@ class {{ leaf.cls_name }}(
 
             {%- for scope, scope_define, props in response.schema.iter_scopes() %}
 
-            {{ scope|avoid_conflict }} = {{ scope_define|avoid_conflict }}
+            {{ scope|avoid_conflict }} = {{ scope_define|handle_keyword }}
 
             {%- for prop_name, prop_type, prop_kwargs, cls_builder_name in props %}
             {{ scope|avoid_conflict }}{{ prop_name|get_prop }} = {{ prop_type }}(

--- a/src/aaz_dev/cli/templates/aaz/command/_cmd.py.j2
+++ b/src/aaz_dev/cli/templates/aaz/command/_cmd.py.j2
@@ -510,7 +510,7 @@ class {{ leaf.cls_name }}(
 
             {%- if scope_define is not none %}
 
-            {{ scope|avoid_conflict }} = {{ op.content.BUILDER_NAME }}.get({{ scope_define|avoid_conflict|constant_convert }})
+            {{ scope|avoid_conflict }} = {{ op.content.BUILDER_NAME }}.get({{ scope_define|constant_convert }})
             if {{ scope|avoid_conflict }} is not None:
             {%- endif %}
 
@@ -520,18 +520,18 @@ class {{ leaf.cls_name }}(
             {%- if prop_name != '[]' and prop_name != '{}' -%}
             {%- if is_const -%}
             {{ scope|avoid_conflict }}.set_const({{ prop_name|constant_convert }}, {{ const_value|constant_convert }}, {{ prop_type }}
-                {%- if arg_key is not none %}, {{ arg_key|constant_convert }}{% endif %}
+                {%- if arg_key is not none %}, {{ arg_key|avoid_conflict|constant_convert }}{% endif %}
                 {%- if prop_type_kwargs is not none and prop_type_kwargs|length %}, typ_kwargs={{ prop_type_kwargs|constant_convert }}{% endif %})
             {%- else -%}
             {{ scope|avoid_conflict }}.set_prop({{ prop_name|constant_convert }}, {{ prop_type }}
-                {%- if arg_key is not none %}, {{ arg_key|constant_convert }}{% endif %}
+                {%- if arg_key is not none %}, {{ arg_key|avoid_conflict|constant_convert }}{% endif %}
                 {%- if prop_type_kwargs is not none and prop_type_kwargs|length %}, typ_kwargs={{ prop_type_kwargs|constant_convert }}{% endif %})
             {%- endif %}
             {%- elif prop_name == '{}' and prop_type is none -%}
-            {{ scope|avoid_conflict }}.set_anytype_elements({%- if arg_key is not none %}{{ arg_key|constant_convert }}{% endif %})
+            {{ scope|avoid_conflict }}.set_anytype_elements({%- if arg_key is not none %}{{ arg_key|avoid_conflict|constant_convert }}{% endif %})
             {%- else -%}
             {{ scope|avoid_conflict }}.set_elements({{ prop_type }}
-                {%- if arg_key is not none %}, {{ arg_key|constant_convert }}{% endif %}
+                {%- if arg_key is not none %}, {{ arg_key|avoid_conflict|constant_convert }}{% endif %}
                 {%- if prop_type_kwargs is not none and prop_type_kwargs|length %}, typ_kwargs={{ prop_type_kwargs|constant_convert }}{% endif %})
             {%- endif %}
             {%- if cls_builder_name is not none %}){% endif %}
@@ -672,7 +672,7 @@ class {{ leaf.cls_name }}(
 
             {%- if scope_define is not none %}
 
-            {{ scope|avoid_conflict }} = {{ op.BUILDER_NAME }}.get({{ scope_define|avoid_conflict|constant_convert }})
+            {{ scope|avoid_conflict }} = {{ op.BUILDER_NAME }}.get({{ scope_define|constant_convert }})
             if {{ scope|avoid_conflict }} is not None:
             {%- endif %}
 
@@ -682,18 +682,18 @@ class {{ leaf.cls_name }}(
             {%- if prop_name != '[]' and prop_name != '{}' -%}
             {%- if is_const -%}
             {{ scope|avoid_conflict }}.set_const({{ prop_name|constant_convert }}, {{ const_value|constant_convert }}, {{ prop_type }}
-                {%- if arg_key is not none %}, {{ arg_key|constant_convert }}{% endif %}
+                {%- if arg_key is not none %}, {{ arg_key|avoid_conflict|constant_convert }}{% endif %}
                 {%- if prop_type_kwargs is not none and prop_type_kwargs|length %}, typ_kwargs={{ prop_type_kwargs|constant_convert }}{% endif %})
             {%- else -%}
             {{ scope|avoid_conflict }}.set_prop({{ prop_name|constant_convert }}, {{ prop_type }}
-                {%- if arg_key is not none %}, {{ arg_key|constant_convert }}{% endif %}
+                {%- if arg_key is not none %}, {{ arg_key|avoid_conflict|constant_convert }}{% endif %}
                 {%- if prop_type_kwargs is not none and prop_type_kwargs|length %}, typ_kwargs={{ prop_type_kwargs|constant_convert }}{% endif %})
             {%- endif %}
             {%- elif prop_name == '{}' and prop_type is none -%}
-            {{ scope|avoid_conflict }}.set_anytype_elements({%- if arg_key is not none %}{{ arg_key|constant_convert }}{% endif %})
+            {{ scope|avoid_conflict }}.set_anytype_elements({%- if arg_key is not none %}{{ arg_key|avoid_conflict|constant_convert }}{% endif %})
             {%- else -%}
             {{ scope|avoid_conflict }}.set_elements({{ prop_type }}
-                {%- if arg_key is not none %}, {{ arg_key|constant_convert }}{% endif %}
+                {%- if arg_key is not none %}, {{ arg_key|avoid_conflict|constant_convert }}{% endif %}
                 {%- if prop_type_kwargs is not none and prop_type_kwargs|length %}, typ_kwargs={{ prop_type_kwargs|constant_convert }}{% endif %})
             {%- endif %}
             {%- if cls_builder_name is not none %}){% endif %}
@@ -750,7 +750,7 @@ class {{ leaf.helper_cls_name }}:
 
         {%- if scope_define is not none %}
 
-        {{ scope|avoid_conflict }} = {{ update_cls.BUILDER_NAME }}.get({{ scope_define|avoid_conflict|constant_convert }})
+        {{ scope|avoid_conflict }} = {{ update_cls.BUILDER_NAME }}.get({{ scope_define|constant_convert }})
         if {{ scope|avoid_conflict }} is not None:
         {%- endif %}
 
@@ -760,18 +760,18 @@ class {{ leaf.helper_cls_name }}:
         {%- if prop_name != '[]' and prop_name != '{}' -%}
         {%- if is_const -%}
         {{ scope|avoid_conflict }}.set_const({{ prop_name|constant_convert }}, {{ const_value|constant_convert }}, {{ prop_type }}
-            {%- if arg_key is not none %}, {{ arg_key|constant_convert }}{% endif %}
+            {%- if arg_key is not none %}, {{ arg_key|avoid_conflict|constant_convert }}{% endif %}
             {%- if prop_type_kwargs is not none and prop_type_kwargs|length %}, typ_kwargs={{ prop_type_kwargs|constant_convert }}{% endif %})
         {%- else -%}
         {{ scope|avoid_conflict }}.set_prop({{ prop_name|constant_convert }}, {{ prop_type }}
-            {%- if arg_key is not none %}, {{ arg_key|constant_convert }}{% endif %}
+            {%- if arg_key is not none %}, {{ arg_key|avoid_conflict|constant_convert }}{% endif %}
             {%- if prop_type_kwargs is not none and prop_type_kwargs|length %}, typ_kwargs={{ prop_type_kwargs|constant_convert }}{% endif %})
         {%- endif %}
         {%- elif prop_name == '{}' and prop_type is none -%}
-        {{ scope|avoid_conflict }}.set_anytype_elements({%- if arg_key is not none %}{{ arg_key|constant_convert }}{% endif %})
+        {{ scope|avoid_conflict }}.set_anytype_elements({%- if arg_key is not none %}{{ arg_key|avoid_conflict|constant_convert }}{% endif %})
         {%- else -%}
         {{ scope|avoid_conflict }}.set_elements({{ prop_type }}
-            {%- if arg_key is not none %}, {{ arg_key|constant_convert }}{% endif %}
+            {%- if arg_key is not none %}, {{ arg_key|avoid_conflict|constant_convert }}{% endif %}
             {%- if prop_type_kwargs is not none and prop_type_kwargs|length %}, typ_kwargs={{ prop_type_kwargs|constant_convert }}{% endif %})
         {%- endif %}
         {%- if cls_builder_name is not none %}){% endif %}


### PR DESCRIPTION
<img width="322" alt="image" src="https://github.com/Azure/aaz-dev-tools/assets/12371639/d8979cc7-39c2-415b-a860-43d427f7508b">

single_trailing_underscore_: used by convention to avoid conflicts with Python keyword

https://peps.python.org/pep-0008/#descriptive-naming-styles