### PR TITLE
Escape backslash in constant_convert

### DIFF
--- a/src/aaz_dev/cli/templates/_filters.py
+++ b/src/aaz_dev/cli/templates/_filters.py
@@ -32,7 +32,7 @@ def is_stable(env, stage):
 @pass_environment
 def constant_convert(env, data):
     if isinstance(data, str):
-        return f'"%s"' % data.replace('"', '\\"').replace('\n', '\\n')
+        return f'"%s"' % data.replace('\\',  '\\\\').replace('"', '\\"').replace('\n', '\\n')
     elif isinstance(data, (int, float, bool)):
         return f"{data}"
     elif data is None:


### PR DESCRIPTION
Continuation of #360.

I just added escaping for backslashes for minimal churn and easy review, but using `repr(data)` could be better instead of escaping manually.