### PR TITLE
Uninherited read-only flag for CMDClsSchemaBase code generation

### DIFF
--- a/src/aaz_dev/cli/controller/az_operation_generator.py
+++ b/src/aaz_dev/cli/controller/az_operation_generator.py
@@ -940,23 +940,23 @@ def render_schema(schema, cls_map, name):
 
 
 def render_schema_base(schema, cls_map, schema_kwargs=None):
+    if schema_kwargs is None:
+        schema_kwargs = {}
+    
+    flags = schema_kwargs.get('flags', {})
+    # read_only is not inherited by class schema, so we need to set it here
+    if schema.read_only:
+        flags['read_only'] = True
+
     if isinstance(schema, CMDClsSchemaBase):
         cls_name = schema.type[1:]
         schema = cls_map[cls_name].schema
     else:
         cls_name = getattr(schema, 'cls', None)
     cls_builder_name = parse_cls_builder_name(cls_name) if cls_name else None
-
-    if schema_kwargs is None:
-        schema_kwargs = {}
-
+   
     if schema.nullable:
         schema_kwargs['nullable'] = True
-
-    flags = schema_kwargs.get('flags', {})
-
-    if schema.read_only:
-        flags['read_only'] = True
 
     if isinstance(schema, CMDStringSchemaBase):
         schema_type = "AAZStrType"

--- a/src/aaz_dev/command/model/configuration/_schema.py
+++ b/src/aaz_dev/command/model/configuration/_schema.py
@@ -397,6 +397,11 @@ class CMDClsSchemaBase(CMDSchemaBase):
             raise NotImplementedError()
         data = {k: v for k, v in self.implement.to_native().items() if k in cls._schema.valid_input_keys}
         data.update(kwargs)
+        # uninherent read_only
+        uninherent = {
+            "read_only": self.read_only,
+        }
+        data.update(uninherent)
         unwrapped = cls(data)
         return unwrapped
 
@@ -879,6 +884,7 @@ class CMDObjectSchemaBase(CMDSchemaBase):
     #  - description
     #  - skip_url_encoding
     #  - client_flatten
+    #  - read_only
     cls = CMDClassField()
 
     def _diff_base(self, old, level, diff):
@@ -993,6 +999,7 @@ class CMDArraySchemaBase(CMDSchemaBase):
     #  - required
     #  - description
     #  - skip_url_encoding
+    #  - read_only
     cls = CMDClassField()
 
     def _get_type(self):


### PR DESCRIPTION
The read-only flag of ClsSchema should not be inherited from the schema definition.