### PR TITLE
handle discriminate_by method in response schema

### DIFF
--- a/src/aaz_dev/cli/templates/_filters.py
+++ b/src/aaz_dev/cli/templates/_filters.py
@@ -86,7 +86,14 @@ def handle_keyword(env, data):
 
     data = data.split(".")
 
-    return data[0] + "".join(get_prop(env, i) for i in data[1:])  # keyword in response, x.else.x -> x["else"].x
+    properties = ""
+    for d in data[1:]:
+        if d in _PYTHON_BUILD_IN_KEYWORDS:
+            properties += get_prop(env, d)
+        else:
+            properties += f".{d}"
+
+    return data[0] + properties  # keyword in response, e.g., x.else.x -> x["else"].x
 
 
 custom_filters = {


### PR DESCRIPTION
the issue is like that:
<img width="652" alt="image" src="https://github.com/Azure/aaz-dev-tools/assets/12371639/c7349f76-1221-496d-8699-294e90de4710">

we don't need to covert that part, only covert "keyword" is enough:
> configuration.discriminate_by("configuration_type", "Deployment")
