### PR TITLE
Release v2.10.0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,12 @@
 
 Release History
 ===============
+2.10.0
+++++++
+* Fix discriminate_by method in generated response schema code (#380)
+* Ignore the required flag for read only property in swagger (#390)
+* Escape backslashes in examples docstrings (#391)
+
 2.9.0
 ++++++
 * Support output flatten control in workspace editor (#368)

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -36,7 +36,7 @@ github:
 pypi: https://pypi.org/project/aaz-dev/
 
 # TODO: get version number from github
-version: v2.9.0
+version: v2.10.0
 
 # Build settings
 theme: minima

--- a/version.py
+++ b/version.py
@@ -1,5 +1,5 @@
 
-_MAJOR, _MINOR, _PATCH, _SUFFIX = ("2", "9", "0", "")
+_MAJOR, _MINOR, _PATCH, _SUFFIX = ("2", "10", "0", "")
 
 # _PATCH: On main and in a nightly release the patch should be one ahead of the last released build.
 # _SUFFIX: This is mainly for nightly builds which have the suffix ".dev$DATE". See


### PR DESCRIPTION
2.10.0
++++++
* Fix discriminate_by method in generated response schema code (#380)
* Ignore the required flag for read only property in swagger (#390)
* Escape backslashes in examples docstrings (#391)