### PR TITLE
Handle 204 response

### DIFF
--- a/src/aaz_dev/command/model/configuration/_command.py
+++ b/src/aaz_dev/command/model/configuration/_command.py
@@ -111,7 +111,6 @@ class CMDCommand(Model):
                     op_output = self.build_output_by_operation(op, pageable, client_flatten)
                     if op_output:
                         output = op_output
-
             if output and ref_outputs:
                 assert len(ref_outputs) == 1, "Only support one reference output"
                 ref_output = ref_outputs[0]
@@ -132,6 +131,9 @@ class CMDCommand(Model):
             if resp.is_error:
                 continue
             if resp.body is None:
+                if 204 in resp.status_codes and op.http.request.method == "delete":
+                    # no content response for delete operation
+                    return None
                 continue
             if isinstance(resp.body, CMDHttpResponseJsonBody):
                 body_json = resp.body.json


### PR DESCRIPTION
For delete operation which contains 204, provide no output. A fix for the [issue](https://teams.microsoft.com/l/message/19:5aaa7fae6eae4b6b9bae42e5295c10a3@thread.tacv2/1731355003112?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=9a661795-1b01-4a5b-9dd5-be571422334c&parentMessageId=1731355003112&teamName=Azure%20CLIs%20partners&channelName=Azure%20CLI%20CodeGen&createdTime=1731355003112).