### PR TITLE
Release v3.2.0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,8 +2,17 @@
 
 Release History
 ===============
+3.2.0
+++++++
+* Handle swagger 204 response (#426)
+* Bump up typespec version and add extern tsp lib for liftr (#427)
+* Apply cls definitions recursively to avoid definition loss (#428)
+* Support generate identity subcommands when using patch only update (#429)
+* Support update command inherent from existing methods used in aaz models (#430)
+* Fix bugs for class name with dot (#431)
+
 3.1.0
-+++++
+++++++
 * Support managed identity sub commands (#403)
 * Support to merge crud operations for the same resource (#415)
 * Support to generate object with props and additional properties as FreeFormDictType in CLI (#415)

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -36,7 +36,7 @@ github:
 pypi: https://pypi.org/project/aaz-dev/
 
 # TODO: get version number from github
-version: v3.1.0
+version: v3.2.0
 
 # Build settings
 theme: minima

--- a/src/aaz_dev/utils/config.py
+++ b/src/aaz_dev/utils/config.py
@@ -5,7 +5,7 @@ from .plane import PlaneEnum
 
 class Config:
 
-    MIN_CLI_CORE_VERSION = version.parse("2.61.0")
+    MIN_CLI_CORE_VERSION = version.parse("2.67.0")
 
     AAZ_PATH = os.environ.get("AAZ_PATH", None)
     SWAGGER_PATH = os.environ.get("AAZ_SWAGGER_PATH", None)

--- a/version.py
+++ b/version.py
@@ -1,5 +1,5 @@
 
-_MAJOR, _MINOR, _PATCH, _SUFFIX = ("3", "1", "0", "")
+_MAJOR, _MINOR, _PATCH, _SUFFIX = ("3", "2", "0", "")
 
 # _PATCH: On main and in a nightly release the patch should be one ahead of the last released build.
 # _SUFFIX: This is mainly for nightly builds which have the suffix ".dev$DATE". See


### PR DESCRIPTION
3.2.0
++++++
* Handle swagger 204 response (#426)
* Bump up typespec version and add extern tsp lib for liftr (#427)
* Apply cls definitions recursively to avoid definition loss (#428)
* Support generate identity subcommands when using patch only update (#429)
* Support update command inherent from existing methods used in aaz models (#430)
* Fix bugs for class name with dot (#431)