### PR TITLE
Enhance performance of `aaz-dev command-model verify`

### DIFF
--- a/src/aaz_dev/command/api/_cmds.py
+++ b/src/aaz_dev/command/api/_cmds.py
@@ -192,15 +192,24 @@ def verify():
             with open(json_path, "r", encoding="utf-8", errors="ignore") as fp:
                 model = json.load(fp)
 
-            for grp in model["commandGroups"]:
-                if grp["name"] == curr_grp:
-                    if not any(cmd["name"] == curr_cmd for cmd in grp["commands"]):
-                        raise Exception(f"There is no {curr_cmd} command info in {json_path}.")
+            group = []
+            while True:
+                try:
+                    group.append(model["commandGroups"][0]["name"])
+                    if " ".join(group) == curr_grp:
+                        break
 
-                    if any(cmd["name"] not in cmd_set for cmd in grp["commands"]):
-                        raise Exception(f"{curr_grp} defined in {json_path} has command that doesn't exist.")
+                    model = model["commandGroups"][0]
 
-                    break
+                except KeyError:
+                    raise Exception(f"{curr_grp} {curr_cmd} is redundant.")
+
+            commands = model["commandGroups"][0]["commands"]
+            if not any(cmd["name"] == curr_cmd for cmd in commands):
+                raise Exception(f"There is no {curr_cmd} command info in {json_path}.")
+
+            if any(cmd["name"] not in cmd_set for cmd in commands):
+                raise Exception(f"{curr_grp} defined in {json_path} has command that doesn't exist.")
 
             model_set.add(json_path)
 

--- a/src/aaz_dev/command/api/_cmds.py
+++ b/src/aaz_dev/command/api/_cmds.py
@@ -176,7 +176,7 @@ def verify():
         curr_grp = " ".join(os.path.relpath(folder, aaz.commands_folder).split(os.sep))
 
         # _command_name.md -> command_name
-        cmd_set = set(map(lambda x: x[1:-3], [f for f in os.listdir(folder) if os.path.isfile(os.path.join(folder, f))]))
+        cmd_set = set(map(lambda x: x[1:-3], [i for i in os.listdir(folder) if os.path.isfile(os.path.join(folder, i))]))
 
         paths = re.findall(r"]\(([^)]+)\)", content)
         for path in paths:
@@ -192,19 +192,20 @@ def verify():
             with open(json_path, "r", encoding="utf-8", errors="ignore") as fp:
                 model = json.load(fp)
 
-            group = []
-            while True:
+            target = curr_grp
+            while target:
                 try:
-                    group.append(model["commandGroups"][0]["name"])
-                    if " ".join(group) == curr_grp:
-                        break
+                    for grp in model["commandGroups"]:
+                        if target.startswith(grp["name"]):
+                            target = target[len(grp["name"]):].strip()
+                            model = grp
 
-                    model = model["commandGroups"][0]
+                            break
 
                 except KeyError:
                     raise Exception(f"{curr_grp} {curr_cmd} is redundant.")
 
-            commands = model["commandGroups"][0]["commands"]
+            commands = model["commands"]
             if not any(cmd["name"] == curr_cmd for cmd in commands):
                 raise Exception(f"There is no {curr_cmd} command info in {json_path}.")
 


### PR DESCRIPTION
As https://github.com/Azure/aaz-dev-tools/pull/409 will drop `tree.json`, we don't need to verify it anymore.

Obviously, the performance will be enhanced and Git Hooks will benefits from that.