### PR TITLE
Add basic response for lro delete operation in typespec-aaz

### DIFF
--- a/src/typespec-aaz/src/convertor.ts
+++ b/src/typespec-aaz/src/convertor.ts
@@ -384,6 +384,21 @@ function extractHttpResponses(context: AAZOperationEmitterContext, operation: Ht
   if (success204Response !== undefined) {
     responses.push(success204Response);
   }
+  const success_status_code = [
+    ...success2xxResponse?.statusCode!,
+    ...success202Response?.statusCode!,
+    ...success204Response?.statusCode!
+  ]
+  const lro_base_status_code = success_status_code.filter(code => [200, 201].includes(code))
+  if (lro_base_status_code.length === 0 && lroMetadata !== undefined && operation.verb === "delete"){
+    const lro_response: CMDHttpResponse = {
+      statusCode: [200, 201],
+      isError: false,
+      description: "Response schema for long-running operation.",
+    };
+    responses.push(lro_response)
+  }
+
   if (redirectResponse !== undefined) {
     responses.push(redirectResponse);
   }

--- a/src/typespec-aaz/src/convertor.ts
+++ b/src/typespec-aaz/src/convertor.ts
@@ -384,17 +384,18 @@ function extractHttpResponses(context: AAZOperationEmitterContext, operation: Ht
   if (success204Response !== undefined) {
     responses.push(success204Response);
   }
-  const success_status_code = [
-    ...success2xxResponse?.statusCode!,
-    ...success202Response?.statusCode!,
-    ...success204Response?.statusCode!
+
+  const success_status_code: number[] = [
+    ...success2xxResponse?.statusCode || [],
+    ...success202Response?.statusCode || [],
+    ...success204Response?.statusCode || [],
   ]
   const lro_base_status_code = success_status_code.filter(code => [200, 201].includes(code))
   if (lro_base_status_code.length === 0 && lroMetadata !== undefined && operation.verb === "delete"){
     const lro_response: CMDHttpResponse = {
       statusCode: [200, 201],
       isError: false,
-      description: "Response schema for long-running operation.",
+      description: "Response schema for long-running operation."
     };
     responses.push(lro_response)
   }


### PR DESCRIPTION
according to swagger codegen pr: https://github.com/Azure/aaz-dev-tools/pull/333 


ref: 
https://github.com/Azure/azure-openapi-validator/blob/main/docs/delete-response-codes.md#output-message

https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/openapi-authoring-automated-guidelines.md#r2064-lrostatuscodesreturntypeschema

https://github.com/Azure/autorest/tree/main/docs/extensions#x-ms-long-running-operation-options
