### PR TITLE
release 4.1.0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,14 @@
 
 Release History
 ===============
+4.1.0
+++++++
+* Fix tag parse and aaz model saving for `aaz-dev command-model generate-from-swagger` and `aaz-dev cli generate-by-swagger-tag` (#444)
+* Fix resources merge with get and put query params inconsistence (#463)
+* Add autogen help message for aaz command group and command (#453)
+* Fix CLI UI set registered as default (#461)
+* typespec: update tsp compiler to 0.65.0 and its dependence and liftr to 0.8.0 (#460)(#464)
+
 4.0.0
 ++++++
 * [Breaking Change] Dropped the dependency on `tree.json` file in aaz repo (#409)

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -36,7 +36,7 @@ github:
 pypi: https://pypi.org/project/aaz-dev/
 
 # TODO: get version number from github
-version: v4.0.0
+version: v4.1.0
 
 # Build settings
 theme: minima

--- a/version.py
+++ b/version.py
@@ -1,5 +1,5 @@
 
-_MAJOR, _MINOR, _PATCH, _SUFFIX = ("4", "0", "0", "")
+_MAJOR, _MINOR, _PATCH, _SUFFIX = ("4", "1", "0", "")
 
 # _PATCH: On main and in a nightly release the patch should be one ahead of the last released build.
 # _SUFFIX: This is mainly for nightly builds which have the suffix ".dev$DATE". See


### PR DESCRIPTION
* Fix tag parse and aaz model saving for `aaz-dev command-model generate-from-swagger` and `aaz-dev cli generate-by-swagger-tag` (#444)
* Fix resources merge with get and put query params inconsistence (#463)
* Add autogen help message for aaz command group and command (#453)
* Fix CLI UI set registered as default (#461)
* typespec: update tsp compiler to 0.65.0 and its dependence and liftr to 0.8.0 (#460)(#464)