### PR TITLE
Adjust ref class name to camel case

### DIFF
--- a/src/typespec-aaz/src/convertor.ts
+++ b/src/typespec-aaz/src/convertor.ts
@@ -3,7 +3,7 @@ import {
   isAzureResource,
 } from "@azure-tools/typespec-azure-resource-manager";
 import { AAZEmitterContext, AAZOperationEmitterContext, AAZSchemaEmitterContext } from "./context.js";
-import { resolveOperationId } from "./utils.js";
+import { resolveOperationId, toCamelCase } from "./utils.js";
 import { TypeSpecPathItem } from "./model/path_item.js";
 import { CMDHttpOperation } from "./model/operation.js";
 import { DiagnosticTarget, Enum, EnumMember, Model, ModelProperty, Namespace, Program, Scalar, TwoLevelMap, Type, Union, Value, getDiscriminator, getDoc, getEncode, getFormat, getMaxItems, getMaxLength, getMaxValue, getMaxValueExclusive, getMinItems, getMinLength, getMinValue, getMinValueExclusive, getPattern, getProjectedName, getProperty, isArrayModelType, isNeverType, isNullType, isRecordModelType, isService, isTemplateDeclaration, isVoidType, resolveEncodedName, IntrinsicType } from "@typespec/compiler";
@@ -1297,17 +1297,18 @@ function processPendingSchemas(context: AAZOperationEmitterContext, verbVisibili
       if (pending.count < 2) {
         pending.ref!.value = undefined;
       } else {
-        let name = getOpenAPITypeName(context.program, type, context.typeNameOptions);
+        const name = getOpenAPITypeName(context.program, type, context.typeNameOptions);
+        let ref_name = toCamelCase(name.replace(/\./g, ' '))
         if (group.size > 1 && visibility !== Visibility.Read) {
           // TODO: handle item
-          name += getVisibilitySuffix(verbVisibility, Visibility.Read);
+          ref_name += getVisibilitySuffix(verbVisibility, Visibility.Read);
         }
         if (Visibility.Read !== visibility) {
-          name += '_' + suffix;
+          ref_name += '_' + suffix;
         } else {
-          name += '_read';
+          ref_name += '_read';
         }
-        pending.ref!.value = name;
+        pending.ref!.value = ref_name;
       }
     }
   }

--- a/src/typespec-aaz/src/utils.ts
+++ b/src/typespec-aaz/src/utils.ts
@@ -116,3 +116,15 @@ function pascalCaseForOperationId(name: string) {
     .map((s) => pascalCase(s))
     .join("_");
 }
+
+
+export function toCamelCase(name: string, delimiters: string = ''): string {
+  const parts = name.replace(/[-_]/g, ' ').split(' ');
+  const camelCasedParts = parts.map((part) => {
+      if (part) {
+          return part.charAt(0).toUpperCase() + part.slice(1).toLowerCase();
+      }
+      return '';
+  });
+  return camelCasedParts.join(delimiters);
+}


### PR DESCRIPTION
tsp model:
```  
  @doc("Error when job fails in it's entirety.")
  @visibility(Lifecycle.Read)
  error?: Azure.Core.Foundations.Error;
```

output:
```
{
    "type": "object",
    "cls": "AzureCoreFoundationsError_read",
    "props": [
    ......
    ],
    "name": "error",
    "description": "Error when job fails in it's entirety.",
    "readOnly": true
}
```
