### PR TITLE
Fix issue caused by or op in isinstance

### DIFF
--- a/src/aaz_dev/command/controller/specs_manager.py
+++ b/src/aaz_dev/command/controller/specs_manager.py
@@ -390,7 +390,7 @@ class AAZSpecsManager:
 
     @staticmethod
     def render_command_tree_readme(tree):
-        assert isinstance(tree, CMDSpecsCommandTree | CMDSpecsPartialCommandTree)
+        assert isinstance(tree, (CMDSpecsCommandTree, CMDSpecsPartialCommandTree))
         tmpl = get_templates()['tree']
         return tmpl.render(tree=tree)
 


### PR DESCRIPTION
Operator `|` in instance is not supported in Python 3.8 and Python 3.9. Use `(A, B)` instead.