### PR TITLE
release 4.2.0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,17 @@
 
 Release History
 ===============
+4.2.0
+++++++
+* Fix issue caused by `or` operation in `isinstance`` (#475)
+* Fix issue caused by properties of not any type (#477)
+* Support merge when renaming a command (#474)
+* Add auto-gen aaz cmds documentation (#478)
+* typespec: update tsp compiler to 0.67.0 (#468)
+* typespec: fix clientRequestIdName in header param and add uuid format parsing (#467)
+* typespec: add support for `any` type of cmd schema (#469)
+* typespec: adjust ref class name to camel case (#472)
+
 4.1.0
 ++++++
 * Fix tag parse and aaz model saving for `aaz-dev command-model generate-from-swagger` and `aaz-dev cli generate-by-swagger-tag` (#444)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,7 @@ Release History
 ===============
 4.2.0
 ++++++
-* Fix issue caused by `or` operation in `isinstance`` (#475)
+* Fix issue caused by `or` operation in `isinstance` (#475)
 * Fix issue caused by properties of not any type (#477)
 * Support merge when renaming a command (#474)
 * Add auto-gen aaz cmds documentation (#478)

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -36,7 +36,7 @@ github:
 pypi: https://pypi.org/project/aaz-dev/
 
 # TODO: get version number from github
-version: v4.1.0
+version: v4.2.0
 
 # Build settings
 theme: minima

--- a/version.py
+++ b/version.py
@@ -1,5 +1,5 @@
 
-_MAJOR, _MINOR, _PATCH, _SUFFIX = ("4", "1", "0", "")
+_MAJOR, _MINOR, _PATCH, _SUFFIX = ("4", "2", "0", "")
 
 # _PATCH: On main and in a nightly release the patch should be one ahead of the last released build.
 # _SUFFIX: This is mainly for nightly builds which have the suffix ".dev$DATE". See


### PR DESCRIPTION
4.2.0
++++++
* Fix issue caused by `or` operation in `isinstance` (#475)
* Fix issue caused by properties of not any type (#477)
* Support merge when renaming a command (#474)
* Add auto-gen aaz cmds documentation (#478)
* typespec: update tsp compiler to 0.67.0 (#468)
* typespec: fix clientRequestIdName in header param and add uuid format parsing (#467)
* typespec: add support for `any` type of cmd schema (#469)
* typespec: adjust ref class name to camel case (#472)