### PR TITLE
Add support for binary request body 

### DIFF
--- a/src/typespec-aaz/src/convertor.ts
+++ b/src/typespec-aaz/src/convertor.ts
@@ -100,6 +100,7 @@ import {
   CMDIdentityObjectSchemaBase,
   CMDBooleanSchemaBase,
   CMDAnyTypeSchemaBase,
+  CMDBinarySchema,
 } from "./model/schema.js";
 import { reportDiagnostic } from "./lib.js";
 import { getExtensions, getOpenAPITypeName, isReadonlyProperty } from "@typespec/openapi";
@@ -373,9 +374,6 @@ function extractHttpRequest(
     if (body.bodyKind === "multipart") {
       throw new Error("NotImplementedError: Multipart form data payloads are not supported.");
     }
-    if (isBinaryPayload(body.type, consumes)) {
-      throw new Error("NotImplementedError: Binary payloads are not supported.");
-    }
     if (consumes.includes("multipart/form-data")) {
       throw new Error("NotImplementedError: Multipart form data payloads are not supported.");
     }
@@ -412,6 +410,12 @@ function extractHttpRequest(
           ...schema,
           clientFlatten: true,
         } as CMDObjectSchema;
+      }
+      if (isBinaryPayload(body.type, consumes)) {
+        schema = {
+          ...schema,
+          type: "binary",
+        } as CMDBinarySchema;
       }
       request.body = {
         json: {

--- a/src/typespec-aaz/test/http-request.test.ts
+++ b/src/typespec-aaz/test/http-request.test.ts
@@ -1,0 +1,49 @@
+import { TestHost, BasicTestRunner } from "@typespec/compiler/testing";
+import { describe, expect, it, beforeEach } from "vitest";
+import { createTypespecAazTestHost, createTypespecAazTestRunner, compileTypespecAAZOperations } from "./test-aaz.js";
+import { findObjectsWithKey } from "./util.js";
+
+describe("http request parsing", () => {
+  let host: TestHost;
+  let runner: BasicTestRunner;
+
+  beforeEach(async () => {
+    host = await createTypespecAazTestHost();
+    runner = await createTypespecAazTestRunner(host);
+  });
+
+  it("validate http request body with bytes", async () => {
+    const code: string = `
+    @versioned(Versions)
+    @service(#{ title: "My service" })
+    namespace Service;
+    enum Versions {A, B, C}
+    model P {
+      @bodyRoot
+      body: bytes;
+    }
+    model Q {
+      q: string;
+    }
+
+    #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "This is a test."
+    @route("/test1")
+    @get
+    op test1(p: P): Q;
+    `;
+    const result = await compileTypespecAAZOperations(
+      code,
+      {
+        "operation": "get-resources-operations",
+        "api-version": "A",
+        "resources": ["/test1"],
+      },
+      runner,
+    );
+    const resultObj = JSON.parse(result!);
+    expect(Array.isArray(resultObj)).toBe(true);
+    expect(resultObj.length).toBe(1);
+    const targetObj = findObjectsWithKey(resultObj[0].pathItem.get.read.http.request, "body");
+    await expect(JSON.stringify(targetObj, null, 2)).toMatchFileSnapshot("./snapshots/http-request-bytes-body.json");
+  });
+});

--- a/src/typespec-aaz/test/snapshots/http-request-bytes-body.json
+++ b/src/typespec-aaz/test/snapshots/http-request-bytes-body.json
@@ -1,0 +1,5 @@
+{
+  "type": "binary",
+  "name": "body",
+  "required": true
+}


### PR DESCRIPTION
tsp request binary body:
```
  @doc("The file content as application/octet-stream.")
  @bodyRoot
   body: bytes;
```
output:
```
{
    "json": {
        "schema": {
            "type": "binary",
            "name": "body",
            "description": "The file content as application/octet-stream.",
            "required": true
        }
    }
}
```