### PR TITLE
Ignore single file for data plane tsp folder check

### DIFF
--- a/src/aaz_dev/swagger/model/specs/_typespec_helper.py
+++ b/src/aaz_dev/swagger/model/specs/_typespec_helper.py
@@ -33,6 +33,8 @@ class TypeSpecHelper:
     @classmethod
     def find_data_plane_entry_files(cls, folder):
         files = []
+        if not os.path.isdir(folder):
+            return files
         for ts_path, cfg_path in cls._iter_entry_files(folder):
             namespace, is_mgmt_plane = cls._parse_main_tsp(ts_path)
             if not namespace:


### PR DESCRIPTION
Tsp folder file check failed when its input is a file:

![image](https://github.com/user-attachments/assets/d9dd2ddb-7e9e-4de7-848f-458896beb11b)
