### PR TITLE
Add rfc1123 datetime

### DIFF
--- a/src/aaz_dev/cli/controller/az_arg_group_generator.py
+++ b/src/aaz_dev/cli/controller/az_arg_group_generator.py
@@ -5,7 +5,7 @@ from command.model.configuration import CMDStringArgBase, CMDByteArgBase, CMDBin
     CMDSubscriptionIdArg, CMDArg
 from command.model.configuration import CMDArgGroup, CMDArgumentHelp
 from command.model.configuration import CMDStringFormat, CMDIntegerFormat, CMDFloatFormat, CMDObjectFormat, \
-    CMDArrayFormat
+    CMDArrayFormat, CMDDateTimeFormat
 from utils.case import to_camel_case, to_snake_case
 from utils import exceptions
 from utils.stage import AAZStageEnum
@@ -357,11 +357,11 @@ def render_arg_base(arg, cmd_ctx, arg_kwargs=None):
             arg_type = "AAZDateArg"
         elif isinstance(arg, CMDDateTimeArgBase):
             arg_type = "AAZDateTimeArg"
-            if arg.is_rfc:
+            if arg.fmt and isinstance(arg.fmt, CMDDateTimeFormat):
                 arg_kwargs['fmt'] = {
                     "cls": "AAZDateTimeFormat",
                     "kwargs": {
-                        "protocol": "rfc"
+                        "protocol": arg.fmt.protocol
                     }
                 }
         elif isinstance(arg, CMDTimeArgBase):

--- a/src/aaz_dev/cli/controller/az_arg_group_generator.py
+++ b/src/aaz_dev/cli/controller/az_arg_group_generator.py
@@ -357,6 +357,13 @@ def render_arg_base(arg, cmd_ctx, arg_kwargs=None):
             arg_type = "AAZDateArg"
         elif isinstance(arg, CMDDateTimeArgBase):
             arg_type = "AAZDateTimeArg"
+            if arg.is_rfc:
+                arg_kwargs['fmt'] = {
+                    "cls": "AAZDateTimeFormat",
+                    "kwargs": {
+                        "protocol": "rfc"
+                    }
+                }
         elif isinstance(arg, CMDTimeArgBase):
             arg_type = "AAZTimeArg"
         elif isinstance(arg, CMDUuidArgBase):

--- a/src/aaz_dev/command/model/configuration/__init__.py
+++ b/src/aaz_dev/command/model/configuration/__init__.py
@@ -41,7 +41,7 @@ from ._fields import CMDBooleanField, CMDStageField, CMDVariantField, CMDClassFi
     CMDPrimitiveField, CMDRegularExpressionField, CMDVersionField, CMDResourceIdField, CMDCommandNameField, \
     CMDCommandGroupNameField, CMDURLPathField, CMDConfirmation
 from ._format import CMDStringFormat, CMDIntegerFormat, CMDFloatFormat, CMDObjectFormat, CMDArrayFormat, \
-    CMDResourceIdFormat
+    CMDResourceIdFormat, CMDDateTimeFormat
 from ._help import CMDHelp, CMDArgumentHelp
 from ._http import CMDHttpRequestArgs, CMDHttpRequestPath, CMDHttpRequestQuery, CMDHttpRequestHeader, \
     CMDHttpRequest, \

--- a/src/aaz_dev/command/model/configuration/_arg.py
+++ b/src/aaz_dev/command/model/configuration/_arg.py
@@ -422,6 +422,15 @@ class CMDDateArg(CMDDateArgBase, CMDStringArg):
 # date-time: As defined by date-time - https://xml2rfc.tools.ietf.org/public/rfc/html/rfc3339.html#anchor14
 class CMDDateTimeArgBase(CMDStringArgBase):
     TYPE_VALUE = "dateTime"
+    # date-time-rfc1123: https://www.apimatic.io/openapi/string-type-format
+    is_rfc = CMDBooleanField()
+
+    @classmethod
+    def build_arg_base(cls, builder):
+        arg = super().build_arg_base(builder)
+        assert isinstance(arg, CMDDateTimeArgBase)
+        arg.is_rfc = builder.get_is_rfc()
+        return arg
 
 
 class CMDDateTimeArg(CMDDateTimeArgBase, CMDStringArg):

--- a/src/aaz_dev/command/model/configuration/_arg.py
+++ b/src/aaz_dev/command/model/configuration/_arg.py
@@ -4,7 +4,7 @@ from schematics.types.serializable import serializable
 
 from ._fields import CMDStageField, CMDVariantField, CMDPrimitiveField, CMDBooleanField, CMDClassField
 from ._format import CMDStringFormat, CMDIntegerFormat, CMDFloatFormat, CMDObjectFormat, CMDArrayFormat, \
-    CMDResourceIdFormat
+    CMDResourceIdFormat, CMDDateTimeFormat
 from ._help import CMDArgumentHelp
 from utils import exceptions
 
@@ -422,15 +422,12 @@ class CMDDateArg(CMDDateArgBase, CMDStringArg):
 # date-time: As defined by date-time - https://xml2rfc.tools.ietf.org/public/rfc/html/rfc3339.html#anchor14
 class CMDDateTimeArgBase(CMDStringArgBase):
     TYPE_VALUE = "dateTime"
-    # date-time-rfc1123: https://www.apimatic.io/openapi/string-type-format
-    is_rfc = CMDBooleanField()
 
-    @classmethod
-    def build_arg_base(cls, builder):
-        arg = super().build_arg_base(builder)
-        assert isinstance(arg, CMDDateTimeArgBase)
-        arg.is_rfc = builder.get_is_rfc()
-        return arg
+    fmt = ModelType(
+        CMDDateTimeFormat,
+        serialized_name='format',
+        deserialize_from='format'
+    )
 
 
 class CMDDateTimeArg(CMDDateTimeArgBase, CMDStringArg):

--- a/src/aaz_dev/command/model/configuration/_arg_builder.py
+++ b/src/aaz_dev/command/model/configuration/_arg_builder.py
@@ -348,11 +348,6 @@ class CMDArgBuilder:
     def get_var(self):
         return self._arg_var
 
-    def get_is_rfc(self):
-        if getattr(self.schema, "is_rfc", False):
-            return True
-        return False
-
     @staticmethod
     def _build_option_name(name):
         name = name.replace('_', '-')

--- a/src/aaz_dev/command/model/configuration/_arg_builder.py
+++ b/src/aaz_dev/command/model/configuration/_arg_builder.py
@@ -348,6 +348,11 @@ class CMDArgBuilder:
     def get_var(self):
         return self._arg_var
 
+    def get_is_rfc(self):
+        if getattr(self.schema, "is_rfc", False):
+            return True
+        return False
+
     @staticmethod
     def _build_option_name(name):
         name = name.replace('_', '-')

--- a/src/aaz_dev/command/model/configuration/_format.py
+++ b/src/aaz_dev/command/model/configuration/_format.py
@@ -174,6 +174,36 @@ class CMDFloatFormat(CMDFormat):
         return diff
 
 
+# datetime format
+class CMDDateTimeFormat(CMDFormat):
+    protocol = StringType(
+        choices=(
+            'iso', # date-time: default to be iso format
+            'rfc', # date-time-rfc1123: https://www.apimatic.io/openapi/string-type-format
+        ),
+        default='iso',
+    )
+
+    def build_arg_fmt(self, builder, ref_fmt):
+        fmt = CMDDateTimeFormat()
+        fmt.protocol = self.protocol
+        return fmt
+
+    def diff(self, old, level):
+        if type(self) is not type(old):
+            return f"Type: {type(old)} != {type(self)}"
+        diff = {}
+
+        if level >= CMDDiffLevelEnum.BreakingChange:
+            if self.protocol and self.protocol == old.protocol and self.protocol != old.protocol:
+                diff["protocol"] = f"from {old.protocol} to {self.protocol}"
+
+        if level >= CMDDiffLevelEnum.Structure:
+            if self.protocol != old.protocol:
+                diff["protocol"] = f"{old.protocol} != {self.protocol}"
+        return diff
+
+
 # object
 class CMDObjectFormat(CMDFormat):
     max_properties = IntType(

--- a/src/aaz_dev/command/model/configuration/_format.py
+++ b/src/aaz_dev/command/model/configuration/_format.py
@@ -196,11 +196,8 @@ class CMDDateTimeFormat(CMDFormat):
 
         if level >= CMDDiffLevelEnum.BreakingChange:
             if self.protocol and self.protocol != old.protocol:
-                diff["protocol"] = f"from {old.protocol} to {self.protocol}"
-
-        if level >= CMDDiffLevelEnum.Structure:
-            if self.protocol and self.protocol != old.protocol:
                 diff["protocol"] = f"{old.protocol} != {self.protocol}"
+
         return diff
 
 

--- a/src/aaz_dev/command/model/configuration/_format.py
+++ b/src/aaz_dev/command/model/configuration/_format.py
@@ -195,11 +195,11 @@ class CMDDateTimeFormat(CMDFormat):
         diff = {}
 
         if level >= CMDDiffLevelEnum.BreakingChange:
-            if self.protocol and self.protocol == old.protocol and self.protocol != old.protocol:
+            if self.protocol and self.protocol != old.protocol:
                 diff["protocol"] = f"from {old.protocol} to {self.protocol}"
 
         if level >= CMDDiffLevelEnum.Structure:
-            if self.protocol != old.protocol:
+            if self.protocol and self.protocol != old.protocol:
                 diff["protocol"] = f"{old.protocol} != {self.protocol}"
         return diff
 

--- a/src/aaz_dev/command/model/configuration/_schema.py
+++ b/src/aaz_dev/command/model/configuration/_schema.py
@@ -532,6 +532,7 @@ class CMDDateSchema(CMDDateSchemaBase, CMDStringSchema):
 class CMDDateTimeSchemaBase(CMDStringSchemaBase):
     TYPE_VALUE = "dateTime"
     ARG_TYPE = CMDDateTimeArgBase
+    is_rfc = CMDBooleanField()
 
 
 class CMDDateTimeSchema(CMDDateTimeSchemaBase, CMDStringSchema):

--- a/src/aaz_dev/command/model/configuration/_schema.py
+++ b/src/aaz_dev/command/model/configuration/_schema.py
@@ -29,7 +29,7 @@ from ._arg import CMDStringArg, CMDStringArgBase, \
     CMDClsArg, CMDClsArgBase, CMDAnyTypeArg, CMDAnyTypeArgBase
 from ._fields import CMDVariantField, StringType, CMDClassField, CMDBooleanField, CMDPrimitiveField, CMDDescriptionField
 from ._format import CMDStringFormat, CMDIntegerFormat, CMDFloatFormat, CMDObjectFormat, CMDArrayFormat, \
-    CMDResourceIdFormat
+    CMDResourceIdFormat, CMDDateTimeFormat
 from ._utils import CMDDiffLevelEnum
 from utils import exceptions
 
@@ -532,8 +532,11 @@ class CMDDateSchema(CMDDateSchemaBase, CMDStringSchema):
 class CMDDateTimeSchemaBase(CMDStringSchemaBase):
     TYPE_VALUE = "dateTime"
     ARG_TYPE = CMDDateTimeArgBase
-    is_rfc = CMDBooleanField()
-
+    fmt = ModelType(
+        CMDDateTimeFormat,
+        serialized_name='format',
+        deserialize_from='format'
+    )
 
 class CMDDateTimeSchema(CMDDateTimeSchemaBase, CMDStringSchema):
     ARG_TYPE = CMDDateTimeArg

--- a/src/aaz_dev/swagger/model/schema/cmd_builder.py
+++ b/src/aaz_dev/swagger/model/schema/cmd_builder.py
@@ -1,5 +1,5 @@
 from command.model.configuration import CMDIntegerFormat, CMDStringFormat, CMDFloatFormat, CMDArrayFormat, \
-    CMDObjectFormat, CMDSchemaEnum, CMDSchemaEnumItem
+    CMDObjectFormat, CMDSchemaEnum, CMDSchemaEnumItem, CMDDateTimeFormat
 
 from command.model.configuration import CMDSchemaDefault, \
     CMDStringSchema, CMDStringSchemaBase, \
@@ -124,8 +124,6 @@ class CMDBuilder:
                     model = CMDDateTimeSchemaBase()
                 else:
                     model = CMDDateTimeSchema()
-                if schema.format == "date-time-rfc1123":
-                    model.is_rfc = True
             elif schema.format == "time":
                 if self.in_base:
                     model = CMDTimeSchemaBase()
@@ -356,7 +354,10 @@ class CMDBuilder:
         if not hasattr(model, 'fmt'):
             return
         fmt = None
-        if isinstance(model, CMDStringSchemaBase):
+        if isinstance(model, CMDDateTimeSchemaBase):
+            # CMDDateTimeSchemaBase is subclass of CMDStringSchemaBase, it needs to be added before following string fmt
+            fmt = self.build_cmd_datetime_format(schema)
+        elif isinstance(model, CMDStringSchemaBase):
             fmt = self.build_cmd_string_format(schema)
         elif isinstance(model, CMDIntegerSchemaBase):
             fmt = self.build_cmd_integer_format(schema)
@@ -425,6 +426,13 @@ class CMDBuilder:
 
         if not fmt_assigned:
             return None
+        return fmt
+
+    @staticmethod
+    def build_cmd_datetime_format(schema):
+        fmt = CMDDateTimeFormat()
+        if schema.format == "date-time-rfc1123":
+            fmt.protocol = "rfc"
         return fmt
 
     @staticmethod

--- a/src/aaz_dev/swagger/model/schema/cmd_builder.py
+++ b/src/aaz_dev/swagger/model/schema/cmd_builder.py
@@ -119,11 +119,13 @@ class CMDBuilder:
                     model = CMDDateSchemaBase()
                 else:
                     model = CMDDateSchema()
-            elif schema.format == "date-time":
+            elif schema.format == "date-time" or schema.format == "date-time-rfc1123":
                 if self.in_base:
                     model = CMDDateTimeSchemaBase()
                 else:
                     model = CMDDateTimeSchema()
+                if schema.format == "date-time-rfc1123":
+                    model.is_rfc = True
             elif schema.format == "time":
                 if self.in_base:
                     model = CMDTimeSchemaBase()

--- a/src/aaz_dev/swagger/model/schema/fields.py
+++ b/src/aaz_dev/swagger/model/schema/fields.py
@@ -6,6 +6,7 @@ class DataTypeFormatEnum(StringType):
         "int32", "int64",
         "float", "double",
         "byte", "binary", "date", "date-time", "time", "password",
+        "date-time-rfc1123",
         # additional formats
         "duration", "uuid",
         "file", "uri",


### PR DESCRIPTION
Currently, codegen already supports `date-time` format, its corresponding arg in cli aaz is `AAZDateTimeArg`, with `AAZDateTimeFormat` using a default protocol `iso`.

For rfc-1123, the difference in cli core is the format protocol to be `rfc`

swagger example: https://github.com/Azure/azure-rest-api-specs/blob/bd98c68b0a0b91e8479f7eb121d488f8f78d4d86/specification/storage/data-plane/Microsoft.BlobStorage/stable/2025-07-05/blob.json#L7148

`date-time` format string:
![image](https://github.com/user-attachments/assets/a42ede59-8efd-4eea-b3ea-4b5e5288d4a4)

`date-time-rfc1123` format string:
![image](https://github.com/user-attachments/assets/ac199b6e-5bd7-4076-98fc-d02bf88872fd)
