### PR TITLE
fix api version mismatch in cli tab

### DIFF
--- a/src/web/src/views/cli/CLIModGeneratorProfileCommandTree.tsx
+++ b/src/web/src/views/cli/CLIModGeneratorProfileCommandTree.tsx
@@ -469,6 +469,7 @@ const CLIModGeneratorProfileCommandTree: React.FC<CLIModGeneratorProfileCommandT
                 unloadedCommand.selected,
                 unloadedCommand.modified,
                 unloadedCommand.registered,
+                unloadedCommand.selectedVersion,
               );
             }) ?? tree
           );
@@ -578,6 +579,7 @@ function decodeProfileCTCommand(
   selected: boolean = false,
   modified: boolean = false,
   registered: boolean | undefined = undefined,
+  selectedVersion: string | undefined = undefined,
 ): ProfileCTCommand {
   const versions = response.versions?.map((value: any) => decodeProfileCTCommandVersion(value));
   const command = {
@@ -591,10 +593,16 @@ function decodeProfileCTCommand(
     registered: registered,
   };
   if (selected) {
-    const selectedVersion = versions ? versions[0].name : undefined;
+    let version: string | undefined;
+    if (selectedVersion !== undefined) {
+      version = selectedVersion;
+    } else {
+      version = versions ? versions[0].name : undefined;
+    }
+
     return {
       ...command,
-      selectedVersion: selectedVersion,
+      selectedVersion: version,
     };
   } else {
     return command;
@@ -607,7 +615,7 @@ function decodeProfileCTCommandGroup(response: CLISpecsCommandGroup, selected: b
       ? Object.fromEntries(
           Object.entries(response.commands).map(([name, command]) => [
             name,
-            decodeProfileCTCommand(command, selected, selected),
+            decodeProfileCTCommand(command, selected, selected, undefined),
           ]),
         )
       : undefined;


### PR DESCRIPTION
info of api version on the disk is missed, always shows the eldest one:
![image](https://github.com/user-attachments/assets/2a85872f-3921-4c4b-bdf0-6757981b521f)

after fix, display the current status:
![image](https://github.com/user-attachments/assets/7da53570-9d84-444b-8fd0-e6d18179e2e2)

