### PR TITLE
release v4.3.0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,19 @@
 
 Release History
 ===============
+4.3.0
+++++++
+* Fix api version mismatch in cli tab (#490)
+* Support get + patch on identity subcommand (#454)
+* Adjust azure-mgmt-core version to fix dep conflict (#487)
+* Add rfc1123 datetime (#485)
+* Update tsp compiler to 1.0.0 (#484)
+* Ignore single file for data plane tsp folder check (#483)
+* Add support for encoding and its default value (#470)
+* Adjust discriminator to reduce duplicated props (#471)
+* Add typespec-aaz emitter test and set prettier config (#481)
+* Fix empty subresource in subcommand (#480)
+
 4.2.0
 ++++++
 * Fix issue caused by `or` operation in `isinstance` (#475)

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -36,7 +36,7 @@ github:
 pypi: https://pypi.org/project/aaz-dev/
 
 # TODO: get version number from github
-version: v4.2.0
+version: v4.3.0
 
 # Build settings
 theme: minima

--- a/src/aaz_dev/utils/config.py
+++ b/src/aaz_dev/utils/config.py
@@ -5,7 +5,7 @@ from .plane import PlaneEnum
 
 class Config:
 
-    MIN_CLI_CORE_VERSION = version.parse("2.70.0")
+    MIN_CLI_CORE_VERSION = version.parse("2.75.0")
 
     AAZ_PATH = os.environ.get("AAZ_PATH", None)
     SWAGGER_PATH = os.environ.get("AAZ_SWAGGER_PATH", None)

--- a/version.py
+++ b/version.py
@@ -1,5 +1,5 @@
 
-_MAJOR, _MINOR, _PATCH, _SUFFIX = ("4", "2", "0", "")
+_MAJOR, _MINOR, _PATCH, _SUFFIX = ("4", "3", "0", "")
 
 # _PATCH: On main and in a nightly release the patch should be one ahead of the last released build.
 # _SUFFIX: This is mainly for nightly builds which have the suffix ".dev$DATE". See


### PR DESCRIPTION
4.3.0
++++++
* Fix api version mismatch in cli tab (#490)
* Support get + patch on identity subcommand (#454)
* Adjust azure-mgmt-core version to fix dep conflict (#487)
* Add rfc1123 datetime (#485)
* Update tsp compiler to 1.0.0 (#484)
* Ignore single file for data plane tsp folder check (#483)
* Add support for encoding and its default value (#470)
* Adjust discriminator to reduce duplicated props (#471)
* Add typespec-aaz emitter test and set prettier config (#481)
* Fix empty subresource in subcommand (#480)