### PR TITLE
build: release v4.4.0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,7 +8,7 @@ Release History
 * GUI heuristics upgrade. (#498)
 * Add `aaz-dev command-model transform` to transform metadata. (#502)
 * Fix TypeSpec entry cannot be parsed well. (#501)
-* Add example generation for update commands.
+* Add example generation for update commands. (#500)
 * Add example generation for `aaz-dev command-model generate-from-swagger`. (#499)
 * Add guild for local development. (#497)
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,15 @@
 Release History
 ===============
 
+4.4.0
+++++++
+* GUI heuristics upgrade. (#498)
+* Add `aaz-dev command-model transform` to transform metadata. (#502)
+* Fix TypeSpec entry cannot be parsed well. (#501)
+* Add example generation for update commands.
+* Add example generation for `aaz-dev command-model generate-from-swagger`. (#499)
+* Add guild for local development. (#497)
+
 4.3.1
 ++++++
 * Upgraded lxml dependency from >=4.9.0 to >=5.0.0 for Python 3.13 compatibility (#495)

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -36,7 +36,7 @@ github:
 pypi: https://pypi.org/project/aaz-dev/
 
 # TODO: get version number from github
-version: v4.3.1
+version: v4.4.0
 
 # Build settings
 theme: minima

--- a/version.py
+++ b/version.py
@@ -1,5 +1,5 @@
 
-_MAJOR, _MINOR, _PATCH, _SUFFIX = ("4", "3", "1", "")
+_MAJOR, _MINOR, _PATCH, _SUFFIX = ("4", "4", "0", "")
 
 # _PATCH: On main and in a nightly release the patch should be one ahead of the last released build.
 # _SUFFIX: This is mainly for nightly builds which have the suffix ".dev$DATE". See


### PR DESCRIPTION
4.4.0
++++++
* GUI heuristics upgrade. (#498)
* Add `aaz-dev command-model transform` to transform metadata. (#502)
* Fix TypeSpec entry cannot be parsed well. (#501)
* Add example generation for update commands. (#500)
* Add example generation for `aaz-dev command-model generate-from-swagger`. (#499)
* Add guild for local development. (#497)