### PR TITLE
Fix missing parameters when generating examples

### DIFF
--- a/src/aaz_dev/swagger/controller/_example_builder.py
+++ b/src/aaz_dev/swagger/controller/_example_builder.py
@@ -79,10 +79,11 @@ class SwaggerExampleBuilder(ExampleBuilder):
         self.cmd_operation = cmd_operation
 
     def mapping(self, example_dict):
-        parameters = self.operation.parameters or []
-        parameters.extend(self.path_item.parameters or [])
+        parameters = dict()
+        for param in (self.operation.parameters or []) + (self.path_item.parameters or []):  # path level `parameters`
+            parameters[param.name] = param
 
-        for param in parameters:
+        for param in parameters.values():
             if param.name not in example_dict:
                 continue
 

--- a/src/aaz_dev/swagger/controller/_example_builder.py
+++ b/src/aaz_dev/swagger/controller/_example_builder.py
@@ -72,13 +72,17 @@ class ExampleBuilder:
 
 
 class SwaggerExampleBuilder(ExampleBuilder):
-    def __init__(self, command=None, operation=None, cmd_operation=None):
+    def __init__(self, command=None, path_item=None, operation=None, cmd_operation=None):
         super().__init__(command=command)
+        self.path_item = path_item
         self.operation = operation
         self.cmd_operation = cmd_operation
 
     def mapping(self, example_dict):
-        for param in self.operation.parameters:
+        parameters = self.operation.parameters or []
+        parameters.extend(self.path_item.parameters or [])
+
+        for param in parameters:
             if param.name not in example_dict:
                 continue
 

--- a/src/aaz_dev/swagger/controller/example_generator.py
+++ b/src/aaz_dev/swagger/controller/example_generator.py
@@ -32,6 +32,7 @@ class ExampleGenerator:
             if path_item.get is not None and path_item.get.operation_id in cmd_operation_ids:
                 example_builder = SwaggerExampleBuilder(
                     command=command,
+                    path_item=path_item,
                     operation=path_item.get,
                     cmd_operation=cmd_operation_ids[path_item.get.operation_id]
                 )
@@ -40,6 +41,7 @@ class ExampleGenerator:
             elif path_item.delete is not None and path_item.delete.operation_id in cmd_operation_ids:
                 example_builder = SwaggerExampleBuilder(
                     command=command,
+                    path_item=path_item,
                     operation=path_item.delete,
                     cmd_operation=cmd_operation_ids[path_item.delete.operation_id]
                 )
@@ -48,6 +50,7 @@ class ExampleGenerator:
             elif path_item.put is not None and path_item.put.operation_id in cmd_operation_ids:
                 example_builder = SwaggerExampleBuilder(
                     command=command,
+                    path_item=path_item,
                     operation=path_item.put,
                     cmd_operation=cmd_operation_ids[path_item.put.operation_id]
                 )
@@ -56,6 +59,7 @@ class ExampleGenerator:
             elif path_item.patch is not None and path_item.patch.operation_id in cmd_operation_ids:
                 example_builder = SwaggerExampleBuilder(
                     command=command,
+                    path_item=path_item,
                     operation=path_item.patch,
                     cmd_operation=cmd_operation_ids[path_item.patch.operation_id]
                 )
@@ -64,6 +68,7 @@ class ExampleGenerator:
             elif path_item.post is not None and path_item.post.operation_id in cmd_operation_ids:
                 example_builder = SwaggerExampleBuilder(
                     command=command,
+                    path_item=path_item,
                     operation=path_item.post,
                     cmd_operation=cmd_operation_ids[path_item.post.operation_id]
                 )
@@ -72,6 +77,7 @@ class ExampleGenerator:
             elif path_item.head is not None and path_item.head.operation_id in cmd_operation_ids:
                 example_builder = SwaggerExampleBuilder(
                     command=command,
+                    path_item=path_item,
                     operation=path_item.head,
                     cmd_operation=cmd_operation_ids[path_item.head.operation_id]
                 )


### PR DESCRIPTION
### Test case
#### Resource ID
/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}
#### API version
2024-07-01

fix: https://github.com/Azure/aaz-dev-tools/issues/425