### PR TITLE
fix: redundant url item

### DIFF
--- a/src/web/src/views/workspace/WSEditorCommandContent.tsx
+++ b/src/web/src/views/workspace/WSEditorCommandContent.tsx
@@ -1311,8 +1311,7 @@ class ExampleDialog extends React.Component<ExampleDialogProps, ExampleDialogSta
         `${workspaceUrl}/CommandTree/Nodes/aaz/` +
         command.names.slice(0, -1).join("/") +
         "/Leaves/" +
-        command.names[command.names.length - 1] +
-        "/GenerateExamples";
+        command.names[command.names.length - 1];
 
       this.setState({
         source: "swagger",


### PR DESCRIPTION
fix: https://github.com/Azure/aaz-dev-tools/issues/520

`GenerateExamples` already exists in https://github.com/Azure/aaz-dev-tools/blob/d2bf829f585cef6a2c51ddcf55f310c62d5cbe8f/src/web/src/services/commandApi.ts#L34.