### PR TITLE
build: release v4.5.1

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,7 @@ Release History
 
 4.5.1
 ++++++
+* Fix validation of schema pattern and error message. (#507)
 * Fix redundant url item within example generation request. (#524)
 * Upgrade `@typespec/compiler` to 1.4.0. (#522)
 * Update the document for generating codes via command-line interface. (#521)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,12 @@
 Release History
 ===============
 
+4.5.1
+++++++
+* Fix redundant url item within example generation request. (#524)
+* Upgrade `@typespec/compiler` to 1.4.0. (#522)
+* Update the document for generating codes via command-line interface. (#521)
+
 4.5.0
 ++++++
 * Add `generate_all` command functionality for CLI generation. (#516)

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -36,7 +36,7 @@ github:
 pypi: https://pypi.org/project/aaz-dev/
 
 # TODO: get version number from github
-version: v4.5.0
+version: v4.5.1
 
 # Build settings
 theme: minima

--- a/version.py
+++ b/version.py
@@ -1,5 +1,5 @@
 
-_MAJOR, _MINOR, _PATCH, _SUFFIX = ("4", "5", "0", "")
+_MAJOR, _MINOR, _PATCH, _SUFFIX = ("4", "5", "1", "")
 
 # _PATCH: On main and in a nightly release the patch should be one ahead of the last released build.
 # _SUFFIX: This is mainly for nightly builds which have the suffix ".dev$DATE". See


### PR DESCRIPTION
4.5.1
++++++
* Fix validation of schema pattern and error message. (#507)
* Fix redundant url item within example generation request. (#524)
* Upgrade `@typespec/compiler` to 1.4.0. (#522)
* Update the document for generating codes via command-line interface. (#521)