### PR TITLE
[Infra]:  filter out typespec-vs from typespec build

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "packageManager": "pnpm@9.5.0",
   "scripts": {
     "run-all": "pnpm -r --filter=\"!./src/typespec/core/\" ",
-    "build:typespec": "pnpm install -C src/typespec/ && pnpm -r --filter=\"!./src/web/\" --filter=\"!./src/typespec/core/\" --filter=\"!./src/typespec/core/packages/typespec-vs\" --workspace-concurrency=Infinity --aggregate-output --reporter=append-only build ",
+    "build:typespec": "pnpm install -C src/typespec/ && pnpm -r --filter=\"!./src/web/\" --filter=\"!./src/typespec/core/\" --workspace-concurrency=Infinity --aggregate-output --reporter=append-only build ",
     "build:web": "pnpm -r --filter=\"./src/web/\" --workspace-concurrency=Infinity --aggregate-output --reporter=append-only build ",
     "bundle": "node ./eng/scripts/bundle_dists.js",
     "test-aaz-emitter": "cd ./src/typespec-aaz && pnpm test-aaz",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "packageManager": "pnpm@9.5.0",
   "scripts": {
     "run-all": "pnpm -r --filter=\"!./src/typespec/core/\" ",
-    "build:typespec": "pnpm install -C src/typespec/ && pnpm -r --filter=\"!./src/web/\" --filter=\"!./src/typespec/core/\" --workspace-concurrency=Infinity --aggregate-output --reporter=append-only build ",
+    "build:typespec": "pnpm install -C src/typespec/ && pnpm -r --filter=\"!./src/web/\" --filter=\"!./src/typespec/core/\" --filter=\"!./src/typespec/core/packages/typespec-vs\" --workspace-concurrency=Infinity --aggregate-output --reporter=append-only build ",
     "build:web": "pnpm -r --filter=\"./src/web/\" --workspace-concurrency=Infinity --aggregate-output --reporter=append-only build ",
     "bundle": "node ./eng/scripts/bundle_dists.js",
     "test-aaz-emitter": "cd ./src/typespec-aaz && pnpm test-aaz",


### PR DESCRIPTION
There is a sec vuln in the `typespec-vs`, is it not required for aaz-dev-tools, so we are filtering it out of typespec build step. 