### PR TITLE
Support Azure CLI Search generation

### DIFF
--- a/src/aaz_dev/cli/api/_cmds.py
+++ b/src/aaz_dev/cli/api/_cmds.py
@@ -57,7 +57,7 @@ def regenerate_code(extension_or_module_name, cli_path=None, cli_extension_path=
         sys.exit(1)
 
     try:
-        if cli_path is not None:
+        if cli_path is not None or Config.CLI_PATH is not None:
             assert Config.CLI_PATH is not None
             manager = AzMainManager()
         else:
@@ -172,7 +172,7 @@ def generate_by_swagger_tag(profile, swagger_tag, extension_or_module_name, cli_
 
         profile = _build_profile(profile, commands_map)
 
-        if cli_path is not None:
+        if cli_path is not None or Config.CLI_PATH is not None:
             assert Config.CLI_PATH is not None
             manager = AzMainManager()
         else:
@@ -321,7 +321,7 @@ def generate(spec, module, cli_path=None):
 
                     commands_map[key] = command.version
 
-        if cli_path is not None:
+        if cli_path is not None or Config.CLI_PATH is not None:
             assert Config.CLI_PATH is not None
             manager = AzMainManager()
 

--- a/src/aaz_dev/cli/controller/az_module_manager.py
+++ b/src/aaz_dev/cli/controller/az_module_manager.py
@@ -36,10 +36,12 @@ class AzModuleManager:
         raise NotImplementedError()
 
     def has_module(self, mod_name):
-        mod_file = os.path.join(self.get_mod_path(mod_name), "setup.py")
-        if not os.path.exists(mod_file):
+        mod_path = self.get_mod_path(mod_name)
+        if not os.path.isdir(mod_path):
             return False
-        return True
+        if os.path.exists(os.path.join(mod_path, "setup.py")):
+            return True
+        return os.path.exists(os.path.join(mod_path, "__init__.py"))
 
     def find_module_cmd_registered(self, node):
         group_nodes = deque()

--- a/src/aaz_dev/cli/controller/az_operation_generator.py
+++ b/src/aaz_dev/cli/controller/az_operation_generator.py
@@ -68,11 +68,7 @@ class AzHttpOperationGenerator(AzOperationGenerator):
             else:
                 if not isinstance(response.body, CMDHttpResponseJsonBody):
                     if not response.body:
-                        raise exceptions.InvalidAPIUsage(
-                            f"Invalid `Error` response schema in operation `{self._operation.operation_id}`: "
-                            f"Missing `schema` property in response "
-                            f"`{response.status_codes or 'default'}`."
-                        )
+                        continue
                     else:
                         raise exceptions.InvalidAPIUsage(
                             f"Invalid `Error` response schema in operation `{self._operation.operation_id}`: "

--- a/src/aaz_dev/command/model/configuration/_http.py
+++ b/src/aaz_dev/command/model/configuration/_http.py
@@ -143,6 +143,8 @@ class CMDHttpRequestHeader(CMDHttpRequestArgs):
 
     def generate_args(self, ref_args, var_prefix=None):
         args = []
+        if not self.params:
+            return args
         if var_prefix:
             if not var_prefix.endswith("$"):
                 var_prefix += '.'

--- a/src/aaz_dev/swagger/controller/command_generator.py
+++ b/src/aaz_dev/swagger/controller/command_generator.py
@@ -381,11 +381,7 @@ class _CommandGenerator(ABC):
             if resp.is_error:
                 if not isinstance(resp.body, CMDHttpResponseJsonBody):
                     if not resp.body:
-                        raise exceptions.InvalidAPIUsage(
-                            f"Invalid `Error` response schema in operation `{op.operation_id}`: "
-                            f"Missing `schema` property in response "
-                            f"`{resp.status_codes or 'default'}`."
-                        )
+                        continue
                     else:
                         raise exceptions.InvalidAPIUsage(
                             f"Invalid `Error` response schema in operation `{op.operation_id}`: "


### PR DESCRIPTION
## Summary

Enable Azure CLI Search command generation for the 2026 preview Search swagger package.

This updates the generator to handle Search-specific shapes encountered while generating the Azure CLI module, including:
- Azure CLI module/path detection for local CLI generation.
- Operations with missing or unusual header parameter metadata.
- Error responses without response schemas.
- Command generation behavior needed by the Search 2026 preview command model.

## Context

These fixes were used with the Search `2026-03-01-preview` swagger package to generate the AAZ Search model and unblock review of the generated command/resource definitions.

## Notes

The generated Search AAZ model currently uses swagger-derived command group names such as `search search-service`; Azure CLI preserves the existing public `az search service` surface separately.