### PR TITLE
Add aaz-dev MCP server

### DIFF
--- a/.github/ISSUE_TEMPLATE/aaz_codegen.yml
+++ b/.github/ISSUE_TEMPLATE/aaz_codegen.yml
@@ -1,0 +1,22 @@
+name: "AAZ Codegen Request"
+description: Ask the codegen bot to inspect an API version and prepare Azure CLI codegen.
+title: "[AAZ Codegen] "
+labels: ["codegen:request"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Describe the API version you want generated in normal language.
+
+        Examples:
+        - Generate Azure CLI for Microsoft.Consumption using API version 2024-08-01.
+        - Please codegen Microsoft.Compute disks at 2025-04-01 for the compute CLI module.
+  - type: textarea
+    id: request
+    attributes:
+      label: Codegen request
+      description: Include the resource provider and API version. Add any useful context for reviewers.
+      placeholder: Generate Azure CLI for Microsoft.Consumption using API version 2024-08-01.
+    validations:
+      required: true
+

--- a/.github/ISSUE_TEMPLATE/aaz_codegen.yml
+++ b/.github/ISSUE_TEMPLATE/aaz_codegen.yml
@@ -16,7 +16,6 @@ body:
     attributes:
       label: Codegen request
       description: Include the resource provider and API version. Add any useful context for reviewers.
-      placeholder: Generate Azure CLI for Microsoft.Consumption using API version 2024-08-01.
+      placeholder: Generate Azure CLI for Microsoft.Cdn using API version 2021-06-01. Use swagger module cdn and CLI module cdn.
     validations:
       required: true
-

--- a/.github/workflows/aaz-codegen-branch-test.yml
+++ b/.github/workflows/aaz-codegen-branch-test.yml
@@ -11,11 +11,11 @@ on:
       issue_title:
         description: Synthetic issue title to extract from.
         required: true
-        default: "AAZ codegen request: Microsoft.Consumption 2024-08-01"
+        default: "AAZ codegen request: Microsoft.Cdn endpoints 2021-06-01"
       issue_body:
         description: Synthetic issue body to extract from.
         required: true
-        default: "Generate Azure CLI code for Microsoft.Consumption using API version 2024-08-01. Target azure-cli main module. CLI module consumption. Profile latest."
+        default: "Generate Azure CLI code for Microsoft.Cdn using API version 2021-06-01. Target azure-cli main module. Swagger module cdn. CLI module cdn. Profile latest. Exact swagger resource paths: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/endpoints and /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/endpoints/{endpointName}."
       spec_ref:
         description: azure-rest-api-specs ref to validate against.
         required: true
@@ -52,8 +52,8 @@ jobs:
     env:
       GITHUB_MODELS_ENDPOINT: https://models.github.ai/inference/chat/completions
       GITHUB_MODELS_MODEL: openai/gpt-4o-mini
-      TEST_ISSUE_TITLE: "${{ github.event.inputs.issue_title || 'AAZ codegen request: Microsoft.Consumption 2024-08-01' }}"
-      TEST_ISSUE_BODY: "${{ github.event.inputs.issue_body || 'Generate Azure CLI code for Microsoft.Consumption using API version 2024-08-01. Target azure-cli main module. CLI module consumption. Profile latest.' }}"
+      TEST_ISSUE_TITLE: "${{ github.event.inputs.issue_title || 'AAZ codegen request: Microsoft.Cdn endpoints 2021-06-01' }}"
+      TEST_ISSUE_BODY: "${{ github.event.inputs.issue_body || 'Generate Azure CLI code for Microsoft.Cdn using API version 2021-06-01. Target azure-cli main module. Swagger module cdn. CLI module cdn. Profile latest. Exact swagger resource paths: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/endpoints and /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/endpoints/{endpointName}.' }}"
       SPEC_REF: "${{ github.event.inputs.spec_ref || 'main' }}"
       RUN_CODEGEN: "${{ github.event.inputs.run_codegen == 'true' || github.event.inputs.publish_prs == 'true' || contains(github.event.head_commit.message || '', '[aaz-codegen-run-test]') || contains(github.event.head_commit.message || '', '[aaz-codegen-pr-test]') }}"
       PUBLISH_PRS: "${{ github.event.inputs.publish_prs == 'true' || contains(github.event.head_commit.message || '', '[aaz-codegen-pr-test]') }}"

--- a/.github/workflows/aaz-codegen-branch-test.yml
+++ b/.github/workflows/aaz-codegen-branch-test.yml
@@ -57,6 +57,7 @@ jobs:
       SPEC_REF: "${{ github.event.inputs.spec_ref || 'main' }}"
       RUN_CODEGEN: "${{ github.event.inputs.run_codegen == 'true' || github.event.inputs.publish_prs == 'true' || contains(github.event.head_commit.message || '', '[aaz-codegen-run-test]') || contains(github.event.head_commit.message || '', '[aaz-codegen-pr-test]') }}"
       PUBLISH_PRS: "${{ github.event.inputs.publish_prs == 'true' || contains(github.event.head_commit.message || '', '[aaz-codegen-pr-test]') }}"
+      SKIP_CLI_CODEGEN: "true"
       CODEGEN_TOKEN: "${{ secrets.CODEGEN_GITHUB_TOKEN }}"
       AAZ_BRANCH: codegen/branch-test-${{ github.run_id }}-aaz
       CLI_BRANCH: codegen/branch-test-${{ github.run_id }}-azure-cli
@@ -141,7 +142,7 @@ jobs:
           token: ${{ env.CODEGEN_TOKEN || github.token }}
 
       - name: Checkout azure-cli
-        if: env.RUN_CODEGEN == 'true'
+        if: env.RUN_CODEGEN == 'true' && env.SKIP_CLI_CODEGEN != 'true'
         uses: actions/checkout@v4
         with:
           repository: Azure/azure-cli
@@ -151,17 +152,23 @@ jobs:
 
       - name: Run deterministic codegen without publishing
         if: env.RUN_CODEGEN == 'true'
+        shell: bash
         run: |
           mkdir -p "$RUNNER_TEMP/aaz-workspaces"
+          cli_args=()
+          if [[ "$SKIP_CLI_CODEGEN" != "true" ]]; then
+            cli_args+=(--cli-path azure-cli)
+          fi
           python -m aaz_dev_mcp.ci.run_issue_codegen \
             --preview codegen-preview.json \
             --swagger-path azure-rest-api-specs \
             --aaz-path aaz \
-            --cli-path azure-cli \
+            "${cli_args[@]}" \
             --workspace-folder "$RUNNER_TEMP/aaz-workspaces" \
             --summary codegen-summary.md \
             --json-out codegen-result.json \
-            --by-patch true
+            --by-patch true \
+            --skip-cli "$SKIP_CLI_CODEGEN"
 
           {
             echo "## Runner-only codegen diff"
@@ -173,7 +180,11 @@ jobs:
             echo
             echo "### Azure/azure-cli"
             echo '```'
-            git -C azure-cli status --short
+            if [[ -d azure-cli ]]; then
+              git -C azure-cli status --short
+            else
+              echo "skipped"
+            fi
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -222,7 +233,11 @@ jobs:
           }
 
           publish_repo "aaz" "Azure/aaz" "main" "$AAZ_BRANCH" "Azure/aaz"
-          publish_repo "azure-cli" "Azure/azure-cli" "dev" "$CLI_BRANCH" "Azure/azure-cli"
+          if [[ -d azure-cli ]]; then
+            publish_repo "azure-cli" "Azure/azure-cli" "dev" "$CLI_BRANCH" "Azure/azure-cli"
+          else
+            echo "- Azure/azure-cli: skipped" >> pr-links.md
+          fi
 
           {
             echo

--- a/.github/workflows/aaz-codegen-branch-test.yml
+++ b/.github/workflows/aaz-codegen-branch-test.yml
@@ -59,6 +59,7 @@ jobs:
       PUBLISH_PRS: "${{ github.event.inputs.publish_prs == 'true' || contains(github.event.head_commit.message || '', '[aaz-codegen-pr-test]') }}"
       SKIP_CLI_CODEGEN: "true"
       CODEGEN_TOKEN: "${{ secrets.CODEGEN_GITHUB_TOKEN }}"
+      CODEGEN_PR_OWNER: "${{ vars.CODEGEN_PR_OWNER || github.repository_owner }}"
       AAZ_BRANCH: codegen/branch-test-${{ github.run_id }}-aaz
       CLI_BRANCH: codegen/branch-test-${{ github.run_id }}-azure-cli
 
@@ -206,10 +207,12 @@ jobs:
 
           publish_repo() {
             local path="$1"
-            local repo="$2"
-            local base="$3"
-            local branch="$4"
-            local label="$5"
+            local base_repo="$2"
+            local head_repo="$3"
+            local base="$4"
+            local branch="$5"
+            local label="$6"
+            local head_owner="${head_repo%%/*}"
 
             if git -C "$path" diff --quiet; then
               echo "- ${label}: no changes" >> pr-links.md
@@ -219,22 +222,23 @@ jobs:
             git -C "$path" checkout -B "$branch"
             git -C "$path" add -A
             git -C "$path" commit -m "Codegen branch test from ${GITHUB_REPOSITORY}@${GITHUB_SHA}"
-            git -C "$path" push --force-with-lease origin "HEAD:${branch}"
+            git -C "$path" remote add codegen "https://x-access-token:${CODEGEN_TOKEN}@github.com/${head_repo}.git"
+            git -C "$path" push --force-with-lease codegen "HEAD:${branch}"
 
             local url
             url="$(gh pr create \
-              --repo "$repo" \
+              --repo "$base_repo" \
               --base "$base" \
-              --head "$branch" \
+              --head "${head_owner}:${branch}" \
               --draft \
               --title "AAZ codegen branch test from ${GITHUB_REF_NAME}" \
               --body-file codegen-summary.md)"
             echo "- ${label}: ${url}" >> pr-links.md
           }
 
-          publish_repo "aaz" "Azure/aaz" "main" "$AAZ_BRANCH" "Azure/aaz"
+          publish_repo "aaz" "Azure/aaz" "${CODEGEN_PR_OWNER}/aaz" "main" "$AAZ_BRANCH" "Azure/aaz"
           if [[ -d azure-cli ]]; then
-            publish_repo "azure-cli" "Azure/azure-cli" "dev" "$CLI_BRANCH" "Azure/azure-cli"
+            publish_repo "azure-cli" "Azure/azure-cli" "${CODEGEN_PR_OWNER}/azure-cli" "dev" "$CLI_BRANCH" "Azure/azure-cli"
           else
             echo "- Azure/azure-cli: skipped" >> pr-links.md
           fi

--- a/.github/workflows/aaz-codegen-branch-test.yml
+++ b/.github/workflows/aaz-codegen-branch-test.yml
@@ -1,0 +1,240 @@
+name: AAZ Codegen Branch Test
+
+on:
+  push:
+    branches-ignore:
+      - main
+      - master
+      - dev
+  workflow_dispatch:
+    inputs:
+      issue_title:
+        description: Synthetic issue title to extract from.
+        required: true
+        default: "AAZ codegen request: Microsoft.Consumption 2024-08-01"
+      issue_body:
+        description: Synthetic issue body to extract from.
+        required: true
+        default: "Generate Azure CLI code for Microsoft.Consumption using API version 2024-08-01. Target azure-cli main module. CLI module consumption. Profile latest."
+      spec_ref:
+        description: azure-rest-api-specs ref to validate against.
+        required: true
+        default: main
+      run_codegen:
+        description: Also run deterministic codegen in runner checkouts without pushing PRs.
+        required: true
+        type: boolean
+        default: false
+      publish_prs:
+        description: Push runner-generated branches and open draft PRs.
+        required: true
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  models: read
+
+concurrency:
+  group: aaz-codegen-branch-test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  branch-smoke:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.head_commit.message || '', '[aaz-codegen-test]') ||
+      contains(github.event.head_commit.message || '', '[aaz-codegen-run-test]') ||
+      contains(github.event.head_commit.message || '', '[aaz-codegen-pr-test]')
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+
+    env:
+      GITHUB_MODELS_ENDPOINT: https://models.github.ai/inference/chat/completions
+      GITHUB_MODELS_MODEL: openai/gpt-4o-mini
+      TEST_ISSUE_TITLE: "${{ github.event.inputs.issue_title || 'AAZ codegen request: Microsoft.Consumption 2024-08-01' }}"
+      TEST_ISSUE_BODY: "${{ github.event.inputs.issue_body || 'Generate Azure CLI code for Microsoft.Consumption using API version 2024-08-01. Target azure-cli main module. CLI module consumption. Profile latest.' }}"
+      SPEC_REF: "${{ github.event.inputs.spec_ref || 'main' }}"
+      RUN_CODEGEN: "${{ github.event.inputs.run_codegen == 'true' || github.event.inputs.publish_prs == 'true' || contains(github.event.head_commit.message || '', '[aaz-codegen-run-test]') || contains(github.event.head_commit.message || '', '[aaz-codegen-pr-test]') }}"
+      PUBLISH_PRS: "${{ github.event.inputs.publish_prs == 'true' || contains(github.event.head_commit.message || '', '[aaz-codegen-pr-test]') }}"
+      CODEGEN_TOKEN: "${{ secrets.CODEGEN_GITHUB_TOKEN }}"
+      AAZ_BRANCH: codegen/branch-test-${{ github.run_id }}-aaz
+      CLI_BRANCH: codegen/branch-test-${{ github.run_id }}-azure-cli
+
+    steps:
+      - name: Checkout aaz-dev-tools
+        uses: actions/checkout@v4
+
+      - name: Checkout azure-rest-api-specs
+        uses: actions/checkout@v4
+        with:
+          repository: Azure/azure-rest-api-specs
+          ref: ${{ env.SPEC_REF }}
+          path: azure-rest-api-specs
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install aaz-dev-tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+
+      - name: Build synthetic issue event
+        run: |
+          python -m aaz_dev_mcp.ci.build_issue_event \
+            --title "$TEST_ISSUE_TITLE" \
+            --body "$TEST_ISSUE_BODY" \
+            --repo "$GITHUB_REPOSITORY" \
+            --out synthetic-issue-event.json
+
+      - name: Build GitHub Models request
+        run: |
+          python -m aaz_dev_mcp.ci.issue_prompt \
+            --event synthetic-issue-event.json \
+            --payload \
+            --model "$GITHUB_MODELS_MODEL" \
+            --out github-models-request.json
+
+      - name: Extract codegen fields with GitHub Models
+        run: |
+          curl --fail-with-body --silent --show-error \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "Accept: application/json" \
+            -H "Content-Type: application/json" \
+            -d @github-models-request.json \
+            "$GITHUB_MODELS_ENDPOINT" \
+            > github-models-response.json
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Build preview
+        run: |
+          python -m aaz_dev_mcp.ci.preview_issue_codegen \
+            --event synthetic-issue-event.json \
+            --llm-response github-models-response.json \
+            --swagger-path azure-rest-api-specs \
+            --out codegen-preview.md \
+            --state codegen-preview.json
+
+          cat codegen-preview.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Checkout aaz
+        if: env.RUN_CODEGEN == 'true'
+        uses: actions/checkout@v4
+        with:
+          repository: Azure/aaz
+          ref: main
+          path: aaz
+          token: ${{ env.CODEGEN_TOKEN || github.token }}
+
+      - name: Checkout azure-cli
+        if: env.RUN_CODEGEN == 'true'
+        uses: actions/checkout@v4
+        with:
+          repository: Azure/azure-cli
+          ref: dev
+          path: azure-cli
+          token: ${{ env.CODEGEN_TOKEN || github.token }}
+
+      - name: Run deterministic codegen without publishing
+        if: env.RUN_CODEGEN == 'true'
+        run: |
+          mkdir -p "$RUNNER_TEMP/aaz-workspaces"
+          python -m aaz_dev_mcp.ci.run_issue_codegen \
+            --preview codegen-preview.json \
+            --swagger-path azure-rest-api-specs \
+            --aaz-path aaz \
+            --cli-path azure-cli \
+            --workspace-folder "$RUNNER_TEMP/aaz-workspaces" \
+            --summary codegen-summary.md \
+            --json-out codegen-result.json \
+            --by-patch true
+
+          {
+            echo "## Runner-only codegen diff"
+            echo
+            echo "### Azure/aaz"
+            echo '```'
+            git -C aaz status --short
+            echo '```'
+            echo
+            echo "### Azure/azure-cli"
+            echo '```'
+            git -C azure-cli status --short
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Push test branches and open draft PRs
+        if: env.PUBLISH_PRS == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${CODEGEN_TOKEN}" ]]; then
+            echo "CODEGEN_GITHUB_TOKEN is required to publish branch-test PRs." >&2
+            exit 2
+          fi
+
+          git config --global user.name "aaz-codegen-bot"
+          git config --global user.email "aaz-codegen-bot@users.noreply.github.com"
+
+          : > pr-links.md
+
+          publish_repo() {
+            local path="$1"
+            local repo="$2"
+            local base="$3"
+            local branch="$4"
+            local label="$5"
+
+            if git -C "$path" diff --quiet; then
+              echo "- ${label}: no changes" >> pr-links.md
+              return
+            fi
+
+            git -C "$path" checkout -B "$branch"
+            git -C "$path" add -A
+            git -C "$path" commit -m "Codegen branch test from ${GITHUB_REPOSITORY}@${GITHUB_SHA}"
+            git -C "$path" push --force-with-lease origin "HEAD:${branch}"
+
+            local url
+            url="$(gh pr create \
+              --repo "$repo" \
+              --base "$base" \
+              --head "$branch" \
+              --draft \
+              --title "AAZ codegen branch test from ${GITHUB_REF_NAME}" \
+              --body-file codegen-summary.md)"
+            echo "- ${label}: ${url}" >> pr-links.md
+          }
+
+          publish_repo "aaz" "Azure/aaz" "main" "$AAZ_BRANCH" "Azure/aaz"
+          publish_repo "azure-cli" "Azure/azure-cli" "dev" "$CLI_BRANCH" "Azure/azure-cli"
+
+          {
+            echo
+            echo "## Draft PRs"
+            cat pr-links.md
+          } >> "$GITHUB_STEP_SUMMARY"
+        env:
+          GH_TOKEN: ${{ env.CODEGEN_TOKEN }}
+
+      - name: Upload branch test artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: aaz-codegen-branch-test-${{ github.run_id }}
+          path: |
+            synthetic-issue-event.json
+            github-models-request.json
+            github-models-response.json
+            codegen-preview.json
+            codegen-preview.md
+            codegen-result.json
+            codegen-summary.md
+            pr-links.md
+          if-no-files-found: ignore

--- a/.github/workflows/aaz-codegen-branch-test.yml
+++ b/.github/workflows/aaz-codegen-branch-test.yml
@@ -65,6 +65,15 @@ jobs:
       - name: Checkout aaz-dev-tools
         uses: actions/checkout@v4
 
+      - name: Validate PR publish token
+        if: env.PUBLISH_PRS == 'true'
+        run: |
+          if [ -z "$CODEGEN_TOKEN" ]; then
+            echo "CODEGEN_GITHUB_TOKEN is required to publish branch-test PRs."
+            echo "Add it as an Actions repository secret on $GITHUB_REPOSITORY."
+            exit 2
+          fi
+
       - name: Checkout azure-rest-api-specs
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/aaz-codegen-preview.yml
+++ b/.github/workflows/aaz-codegen-preview.yml
@@ -1,0 +1,101 @@
+name: AAZ Codegen Preview
+
+on:
+  issues:
+    types: [opened, edited, labeled]
+
+permissions:
+  contents: read
+  issues: write
+  models: read
+
+concurrency:
+  group: aaz-codegen-preview-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    if: contains(github.event.issue.labels.*.name, 'codegen:request')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    env:
+      GITHUB_MODELS_ENDPOINT: https://models.github.ai/inference/chat/completions
+      GITHUB_MODELS_MODEL: openai/gpt-4o-mini
+
+    steps:
+      - name: Checkout aaz-dev-tools
+        uses: actions/checkout@v4
+
+      - name: Checkout azure-rest-api-specs
+        uses: actions/checkout@v4
+        with:
+          repository: Azure/azure-rest-api-specs
+          ref: main
+          path: azure-rest-api-specs
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install aaz-dev-tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+
+      - name: Build GitHub Models request
+        run: |
+          python -m aaz_dev_mcp.ci.issue_prompt \
+            --event "$GITHUB_EVENT_PATH" \
+            --payload \
+            --model "$GITHUB_MODELS_MODEL" \
+            --out github-models-request.json
+
+      - name: Extract codegen fields with GitHub Models
+        run: |
+          curl --fail-with-body --silent --show-error \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "Accept: application/json" \
+            -H "Content-Type: application/json" \
+            -d @github-models-request.json \
+            "$GITHUB_MODELS_ENDPOINT" \
+            > github-models-response.json
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Build preview comment
+        run: |
+          python -m aaz_dev_mcp.ci.preview_issue_codegen \
+            --event "$GITHUB_EVENT_PATH" \
+            --llm-response github-models-response.json \
+            --swagger-path azure-rest-api-specs \
+            --out codegen-preview.md \
+            --state codegen-preview.json
+
+      - name: Comment preview on issue
+        run: gh issue comment "$ISSUE_NUMBER" --body-file codegen-preview.md
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+
+      - name: Comment preview failure on issue
+        if: failure()
+        run: |
+          gh issue comment "$ISSUE_NUMBER" --body "AAZ codegen preview failed. See workflow run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+
+      - name: Upload preview artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: aaz-codegen-preview-${{ github.event.issue.number }}
+          path: |
+            github-models-request.json
+            github-models-response.json
+            codegen-preview.json
+            codegen-preview.md
+          if-no-files-found: ignore

--- a/.github/workflows/aaz-codegen-run.yml
+++ b/.github/workflows/aaz-codegen-run.yml
@@ -23,6 +23,7 @@ jobs:
 
     env:
       CODEGEN_TOKEN: ${{ secrets.CODEGEN_GITHUB_TOKEN || github.token }}
+      CODEGEN_PR_OWNER: ${{ vars.CODEGEN_PR_OWNER || github.repository_owner }}
       ISSUE_NUMBER: ${{ github.event.issue.number }}
       AAZ_BRANCH: codegen/issue-${{ github.event.issue.number }}-aaz
       CLI_BRANCH: codegen/issue-${{ github.event.issue.number }}-azure-cli
@@ -99,10 +100,12 @@ jobs:
 
           publish_repo() {
             local path="$1"
-            local repo="$2"
-            local base="$3"
-            local branch="$4"
-            local label="$5"
+            local base_repo="$2"
+            local head_repo="$3"
+            local base="$4"
+            local branch="$5"
+            local label="$6"
+            local head_owner="${head_repo%%/*}"
 
             if git -C "$path" diff --quiet; then
               echo "- ${label}: no changes" >> pr-links.md
@@ -112,10 +115,11 @@ jobs:
             git -C "$path" checkout -B "$branch"
             git -C "$path" add -A
             git -C "$path" commit -m "Codegen from aaz-dev-tools-mcp issue #${ISSUE_NUMBER}"
-            git -C "$path" push --force-with-lease origin "HEAD:${branch}"
+            git -C "$path" remote add codegen "https://x-access-token:${CODEGEN_TOKEN}@github.com/${head_repo}.git"
+            git -C "$path" push --force-with-lease codegen "HEAD:${branch}"
 
             local existing
-            existing="$(gh pr list --repo "$repo" --head "$branch" --json url --jq '.[0].url // empty')"
+            existing="$(gh pr list --repo "$base_repo" --head "${head_owner}:${branch}" --json url --jq '.[0].url // empty')"
             if [[ -n "$existing" ]]; then
               gh pr edit "$existing" \
                 --title "AAZ codegen for issue #${ISSUE_NUMBER}" \
@@ -124,9 +128,9 @@ jobs:
             else
               local url
               url="$(gh pr create \
-                --repo "$repo" \
+                --repo "$base_repo" \
                 --base "$base" \
-                --head "$branch" \
+                --head "${head_owner}:${branch}" \
                 --draft \
                 --title "AAZ codegen for issue #${ISSUE_NUMBER}" \
                 --body-file codegen-summary.md)"
@@ -134,8 +138,8 @@ jobs:
             fi
           }
 
-          publish_repo "aaz" "Azure/aaz" "main" "$AAZ_BRANCH" "Azure/aaz"
-          publish_repo "azure-cli" "Azure/azure-cli" "dev" "$CLI_BRANCH" "Azure/azure-cli"
+          publish_repo "aaz" "Azure/aaz" "${CODEGEN_PR_OWNER}/aaz" "main" "$AAZ_BRANCH" "Azure/aaz"
+          publish_repo "azure-cli" "Azure/azure-cli" "${CODEGEN_PR_OWNER}/azure-cli" "dev" "$CLI_BRANCH" "Azure/azure-cli"
 
           {
             cat codegen-summary.md
@@ -170,4 +174,3 @@ jobs:
             pr-links.md
             codegen-result.md
           if-no-files-found: ignore
-

--- a/.github/workflows/aaz-codegen-run.yml
+++ b/.github/workflows/aaz-codegen-run.yml
@@ -1,0 +1,173 @@
+name: AAZ Codegen Run
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: aaz-codegen-run-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  run-codegen:
+    if: >-
+      github.event.issue.pull_request == null &&
+      startsWith(github.event.comment.body, '/codegen') &&
+      contains(github.event.issue.labels.*.name, 'codegen:request')
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+
+    env:
+      CODEGEN_TOKEN: ${{ secrets.CODEGEN_GITHUB_TOKEN || github.token }}
+      ISSUE_NUMBER: ${{ github.event.issue.number }}
+      AAZ_BRANCH: codegen/issue-${{ github.event.issue.number }}-aaz
+      CLI_BRANCH: codegen/issue-${{ github.event.issue.number }}-azure-cli
+
+    steps:
+      - name: Checkout aaz-dev-tools
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install aaz-dev-tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+
+      - name: Load latest valid preview
+        run: |
+          python -m aaz_dev_mcp.ci.find_preview \
+            --event "$GITHUB_EVENT_PATH" \
+            --out codegen-preview.json
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Checkout azure-rest-api-specs
+        uses: actions/checkout@v4
+        with:
+          repository: Azure/azure-rest-api-specs
+          ref: main
+          path: azure-rest-api-specs
+
+      - name: Checkout aaz
+        uses: actions/checkout@v4
+        with:
+          repository: Azure/aaz
+          ref: main
+          path: aaz
+          token: ${{ env.CODEGEN_TOKEN }}
+
+      - name: Checkout azure-cli
+        uses: actions/checkout@v4
+        with:
+          repository: Azure/azure-cli
+          ref: dev
+          path: azure-cli
+          token: ${{ env.CODEGEN_TOKEN }}
+
+      - name: Run deterministic codegen
+        run: |
+          mkdir -p "$RUNNER_TEMP/aaz-workspaces"
+          python -m aaz_dev_mcp.ci.run_issue_codegen \
+            --preview codegen-preview.json \
+            --swagger-path azure-rest-api-specs \
+            --aaz-path aaz \
+            --cli-path azure-cli \
+            --workspace-folder "$RUNNER_TEMP/aaz-workspaces" \
+            --summary codegen-summary.md \
+            --json-out codegen-result.json \
+            --by-patch true
+
+      - name: Push branches and open draft PRs
+        id: prs
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          git config --global user.name "aaz-codegen-bot"
+          git config --global user.email "aaz-codegen-bot@users.noreply.github.com"
+
+          : > pr-links.md
+
+          publish_repo() {
+            local path="$1"
+            local repo="$2"
+            local base="$3"
+            local branch="$4"
+            local label="$5"
+
+            if git -C "$path" diff --quiet; then
+              echo "- ${label}: no changes" >> pr-links.md
+              return
+            fi
+
+            git -C "$path" checkout -B "$branch"
+            git -C "$path" add -A
+            git -C "$path" commit -m "Codegen from aaz-dev-tools-mcp issue #${ISSUE_NUMBER}"
+            git -C "$path" push --force-with-lease origin "HEAD:${branch}"
+
+            local existing
+            existing="$(gh pr list --repo "$repo" --head "$branch" --json url --jq '.[0].url // empty')"
+            if [[ -n "$existing" ]]; then
+              gh pr edit "$existing" \
+                --title "AAZ codegen for issue #${ISSUE_NUMBER}" \
+                --body-file codegen-summary.md
+              echo "- ${label}: ${existing}" >> pr-links.md
+            else
+              local url
+              url="$(gh pr create \
+                --repo "$repo" \
+                --base "$base" \
+                --head "$branch" \
+                --draft \
+                --title "AAZ codegen for issue #${ISSUE_NUMBER}" \
+                --body-file codegen-summary.md)"
+              echo "- ${label}: ${url}" >> pr-links.md
+            fi
+          }
+
+          publish_repo "aaz" "Azure/aaz" "main" "$AAZ_BRANCH" "Azure/aaz"
+          publish_repo "azure-cli" "Azure/azure-cli" "dev" "$CLI_BRANCH" "Azure/azure-cli"
+
+          {
+            cat codegen-summary.md
+            echo
+            echo "### Pull Requests"
+            cat pr-links.md
+          } > codegen-result.md
+        env:
+          GH_TOKEN: ${{ env.CODEGEN_TOKEN }}
+
+      - name: Comment result on issue
+        run: gh issue comment "$ISSUE_NUMBER" --body-file codegen-result.md
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Comment failure on issue
+        if: failure()
+        run: |
+          gh issue comment "$ISSUE_NUMBER" --body "AAZ codegen failed. See workflow run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Upload run artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: aaz-codegen-run-${{ github.event.issue.number }}
+          path: |
+            codegen-preview.json
+            codegen-result.json
+            codegen-summary.md
+            pr-links.md
+            codegen-result.md
+          if-no-files-found: ignore
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+.PHONY: help mcp mcp-install venv
+
+VENV ?= .venv
+PYTHON ?= python3
+ACTIVATE := . $(VENV)/bin/activate
+
+help:
+	@echo "Available targets:"
+	@echo "  make venv         Create the local Python virtualenv ($(VENV))"
+	@echo "  make mcp-install  Install aaz-dev-tools + aaz-dev-mcp into $(VENV)"
+	@echo "  make mcp          Start the aaz-dev MCP server over stdio"
+
+$(VENV)/bin/activate:
+	$(PYTHON) -m venv $(VENV)
+
+venv: $(VENV)/bin/activate
+
+mcp-install: venv
+	$(ACTIVATE) && pip install -e . && pip install -e src/aaz_dev_mcp
+
+mcp: venv
+	@if [ ! -x "$(VENV)/bin/aaz-dev-mcp" ]; then \
+		echo "aaz-dev-mcp not installed; run 'make mcp-install' first." >&2; \
+		exit 1; \
+	fi
+	$(ACTIVATE) && aaz-dev-mcp

--- a/src/aaz_dev_mcp/README.md
+++ b/src/aaz_dev_mcp/README.md
@@ -60,8 +60,8 @@ codegen. It does not run the MCP stdio server in CI; it calls the shared Python
 helpers directly.
 
 1. Create an **AAZ Codegen Request** issue and describe the API version in
-   prose, e.g. `Generate Azure CLI for Microsoft.Consumption using API version
-   2024-08-01.`
+   prose, e.g. `Generate Azure CLI for Microsoft.Cdn using API version
+   2021-06-01.`
 2. The `codegen:request` label triggers `.github/workflows/aaz-codegen-preview.yml`.
    The workflow calls GitHub Models with the built-in `GITHUB_TOKEN`
    (`models: read`) to extract candidate fields, validates them against

--- a/src/aaz_dev_mcp/README.md
+++ b/src/aaz_dev_mcp/README.md
@@ -1,0 +1,158 @@
+# aaz-dev-mcp
+
+A [Model Context Protocol](https://modelcontextprotocol.io) server that exposes
+[aaz-dev-tools](https://github.com/Azure/aaz-dev-tools) workflows as tools an
+LLM agent can call. It wraps the same Python controllers the web UI uses, so
+generated CLI code is identical to what you'd get by clicking through the
+browser.
+
+## Scope (v1)
+
+Reproduce the end-to-end flow of an Azure CLI swagger-version bump PR (e.g.
+[azure-cli#33222](https://github.com/Azure/azure-cli/pull/33222)):
+
+1. Configure repo paths.
+2. Create or load a workspace.
+3. Add swagger resources at a specific API version.
+4. (Optional) tweak help text on command groups.
+5. Generate to the `aaz` repo.
+6. Select per-command versions for an azure-cli module and regenerate Python code.
+
+## Install
+
+This package depends on `aaz-dev-tools` itself being installed in the same
+Python environment.
+
+```bash
+# from the repo root
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .                # installs aaz-dev-tools controllers
+pip install -e src/aaz_dev_mcp  # installs aaz-dev-mcp + MCP SDK
+```
+
+## Configuration
+
+The server reads the same environment variables aaz-dev-tools uses:
+
+| Variable | Purpose |
+| --- | --- |
+| `AAZ_PATH` | clone of `Azure/aaz` |
+| `AAZ_SWAGGER_PATH` | clone of `Azure/azure-rest-api-specs` |
+| `AAZ_CLI_PATH` | clone of `Azure/azure-cli` |
+| `AAZ_CLI_EXTENSION_PATH` | clone of `Azure/azure-cli-extensions` |
+| `AAZ_DEV_WORKSPACE_FOLDER` | where workspace ws.json files live (default `~/.aaz_dev/workspaces` — same default as the Flask UI, so workspaces are shared by default) |
+
+You can also override at runtime by calling the `configure` tool first.
+
+## Running
+
+The server speaks MCP over **stdio**:
+
+```bash
+aaz-dev-mcp
+```
+
+### Claude Desktop / OpenCode config snippet
+
+```json
+{
+  "mcpServers": {
+    "aaz-dev": {
+      "command": "/absolute/path/to/.venv/bin/aaz-dev-mcp",
+      "env": {
+        "AAZ_PATH": "/Users/you/workspaces/aaz",
+        "AAZ_SWAGGER_PATH": "/Users/you/workspaces/azure-rest-api-specs",
+        "AAZ_CLI_PATH": "/Users/you/workspaces/azure-cli",
+        "AAZ_CLI_EXTENSION_PATH": "/Users/you/workspaces/azure-cli-extensions"
+      }
+    }
+  }
+}
+```
+
+## Sharing workspaces with the Flask UI
+
+Workspaces are not MCP-specific. Both the MCP server and the Flask UI in
+`aaz-dev` go through the same `WorkspaceManager`, which stores each
+workspace as `<AAZ_DEV_WORKSPACE_FOLDER>/<name>/{ws.json, Resources/...}`
+on disk.
+
+If both processes use the same `AAZ_DEV_WORKSPACE_FOLDER` (the default
+`~/.aaz_dev/workspaces` for both), an MCP-created workspace shows up in
+the UI's workspace list automatically and you can edit its command tree,
+arguments, examples, etc., in the browser. Likewise, the MCP can `load`
+and modify workspaces that were created in the UI.
+
+A few things to keep in mind:
+
+- **No IPC** — if you have the UI open while the MCP writes the same
+  workspace (or vice versa), the UI's in-memory copy is stale. Refresh.
+- **Optimistic concurrency** — `WorkspaceManager.save()` compares a
+  `ws.version` UTC timestamp against the on-disk copy
+  (`workspace_manager.py:213`). Concurrent saves to the same workspace
+  fail with `ResourceConflict("Workspace Changed after: ...")` rather
+  than corrupting state. Re-load and retry.
+- **Other paths must also match** — if the UI's `AAZ_PATH` /
+  `AAZ_CLI_PATH` / etc. point at different checkouts than the MCP's,
+  `generate_to_aaz` and `update_*_module` from each side write to
+  different repos. Keep them aligned (or be intentional about the split,
+  e.g. UI -> real repos, MCP -> worktrees).
+
+## Tools
+
+| Tool | Purpose |
+| --- | --- |
+| `configure` | Set/inspect paths to aaz, swagger, cli, extensions, workspace folder. |
+| `list_workspaces` | List ws.json folders under the configured workspace folder. |
+| `create_workspace` | Create a new workspace. Errors if it already exists. |
+| `load_workspace` | Load an existing workspace's command tree. |
+| `add_swagger_resources` | Add ARM resource paths at a given API version into the workspace. |
+| `set_node_help` | Update help text / stage on a command-group node. |
+| `set_command_help` | Update help text / stage on a leaf command. |
+| `rename_command_group` | Rename or re-parent a command-group node, e.g. `node_names=["consumption","usage-detail"]` → `new_node_names=["consumption","usage"]`. |
+| `rename_command` | Rename or re-parent a leaf command, e.g. `leaf_names=["consumption","pricesheet","default","show"]` → `new_leaf_names=["consumption","pricesheet","show"]`. |
+| `update_argument` | Patch a single argument on a leaf (options/help/stage/hide/group/singular_options). Use to add aliases like `--name`/`-n` to `--budget-name`. Pass `clear_group=True` to ungroup an arg. |
+| `flatten_argument` | Flatten an object argument into its sub-arguments (e.g. `--time-period` → `--start-date` + `--end-date`). |
+| `unflatten_argument` | Inverse of `flatten_argument`. |
+| `list_command_examples` | Read the current examples on a leaf command. |
+| `add_command_example` | Append a single manual `{name, commands}` example (mirrors the editor's "Add Example" dialog). |
+| `add_examples_from_swagger` | Generate examples from the OpenAPI spec (the editor's "By OpenAPI Specification" button) and persist them; supports `replace=False/True`. |
+| `set_command_examples` | Replace the full example list on a leaf (pass `[]` to clear). |
+| `generate_to_aaz` | Export the workspace command tree to the `aaz` repo. |
+| `get_main_module` / `get_extension_module` | Read the current CLI profile for an azure-cli or extensions module. |
+| `update_main_module` / `update_extension_module` | Generate CLI code from a full profiles dict. Accepts `by_patch` (default `true`). |
+| `select_command_versions` | High-level: pick `{command: version}` and generate. Accepts `by_patch` (default `true`). |
+
+## Typical workflow
+
+1. `configure(...)` (or rely on env vars)
+2. `create_workspace(name="consumption-2024-08-01", mod_names="consumption", resource_provider="Microsoft.Consumption")`
+3. `add_swagger_resources(name=..., module="consumption", version="2024-08-01", resource_paths=[...])`
+4. `rename_command_group(name=..., node_names=["consumption","usage-detail"], new_node_names=["consumption","usage"])` (and similar for `reservation-summary` → `reservation summary`, `reservation-detail` → `reservation detail`; `rename_command` for `pricesheet default show` → `pricesheet show`).
+5. `set_node_help(name=..., node_names=["consumption","budget"], help={"short": "Manage consumption budgets."})` (optional)
+6. `generate_to_aaz(name=...)`
+7. `select_command_versions(target="main", module_name="consumption", by_patch=False, command_versions={"consumption budget create": "2024-08-01", ...})`
+
+### `by_patch` semantics
+
+`by_patch` (passed to `update_*_module` / `select_command_versions`) only
+controls whether unmodified commands re-read their existing config files.
+It does **not** preserve commands that are absent from the input profile —
+codegen always rewrites the entire `aaz/latest/` tree.
+
+If you are introducing brand-new leaves (e.g. `consumption usage list`,
+`consumption reservation summary list`) that don't yet exist in the CLI
+module, you must pass `by_patch=False`. Otherwise the profile generator
+hits `AssertionError: command.cfg is not None`
+(`az_profile_generator.py:103`).
+
+## Notes
+
+- Each tool catches `ValueError` from `Config` setters and returns it as a
+  structured error.
+- Errors raised by controllers (`exceptions.ResourceConflict`,
+  `exceptions.InvalidAPIUsage`, etc.) propagate as MCP tool errors.
+- Workspaces use optimistic concurrency: a `ws.version` timestamp is checked
+  on every save. If you run the Flask dev server and the MCP simultaneously
+  and both write the same workspace, the second writer will error.

--- a/src/aaz_dev_mcp/README.md
+++ b/src/aaz_dev_mcp/README.md
@@ -53,6 +53,52 @@ The server speaks MCP over **stdio**:
 aaz-dev-mcp
 ```
 
+## GitHub Actions issue codegen
+
+This repo also includes a lightweight GitHub Actions flow for issue-driven
+codegen. It does not run the MCP stdio server in CI; it calls the shared Python
+helpers directly.
+
+1. Create an **AAZ Codegen Request** issue and describe the API version in
+   prose, e.g. `Generate Azure CLI for Microsoft.Consumption using API version
+   2024-08-01.`
+2. The `codegen:request` label triggers `.github/workflows/aaz-codegen-preview.yml`.
+   The workflow calls GitHub Models with the built-in `GITHUB_TOKEN`
+   (`models: read`) to extract candidate fields, validates them against
+   `Azure/azure-rest-api-specs@main`, and comments a preview.
+3. Comment `/codegen` on an issue with a valid preview to run
+   `.github/workflows/aaz-codegen-run.yml`. The run uses the latest valid bot
+   preview, generates into `Azure/aaz` and `Azure/azure-cli`, and opens or
+   updates draft PRs.
+
+The `/codegen` workflow never writes to a developer's local checkout. It checks
+out fresh copies of `Azure/aaz`, `Azure/azure-cli`, and `Azure/azure-rest-api-specs`
+inside the GitHub Actions runner workspace, modifies those runner worktrees,
+then pushes bot branches and opens or updates draft PRs.
+
+GitHub Models does not require Azure OpenAI secrets. Cross-repo PR creation
+still requires a token that can push branches and open PRs in `Azure/aaz` and
+`Azure/azure-cli`; configure it as `CODEGEN_GITHUB_TOKEN`. Without that secret,
+the workflow falls back to `GITHUB_TOKEN`, which usually cannot write to those
+repos from this control repo.
+
+### Testing the flow from a branch
+
+GitHub issue and issue-comment events are repository events, so they are not a
+good way to test a brand-new workflow file that only exists on a feature branch.
+Use `.github/workflows/aaz-codegen-branch-test.yml` for pre-merge smoke tests.
+
+Push a commit whose message contains `[aaz-codegen-test]` to run the GitHub
+Models extraction and preview validation against a synthetic issue. Use
+`[aaz-codegen-run-test]` to also run deterministic codegen against fresh runner
+checkouts of `Azure/aaz` and `Azure/azure-cli`.
+
+To test draft PR creation before merging the issue workflow, configure
+`CODEGEN_GITHUB_TOKEN`, then push a commit whose message contains
+`[aaz-codegen-pr-test]`. That mode still uses fresh runner checkouts, but it
+also pushes generated branches to `Azure/aaz` and `Azure/azure-cli` and opens
+draft PRs. It never comments on GitHub issues.
+
 ### Claude Desktop / OpenCode config snippet
 
 ```json

--- a/src/aaz_dev_mcp/__init__.py
+++ b/src/aaz_dev_mcp/__init__.py
@@ -1,0 +1,3 @@
+"""aaz-dev-mcp: Model Context Protocol server wrapping aaz-dev-tools controllers."""
+
+__version__ = "0.1.0"

--- a/src/aaz_dev_mcp/ci/__init__.py
+++ b/src/aaz_dev_mcp/ci/__init__.py
@@ -1,0 +1,2 @@
+"""GitHub Actions helpers for issue-driven AAZ code generation."""
+

--- a/src/aaz_dev_mcp/ci/build_issue_event.py
+++ b/src/aaz_dev_mcp/ci/build_issue_event.py
@@ -1,0 +1,57 @@
+"""Build a small GitHub issue event payload for CI smoke tests."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def build_issue_event(
+    *,
+    title: str,
+    body: str,
+    number: int,
+    repo: str,
+    comments_url: str | None = None,
+) -> dict:
+    if comments_url is None and number:
+        comments_url = f"https://api.github.com/repos/{repo}/issues/{number}/comments"
+
+    return {
+        "issue": {
+            "number": number,
+            "title": title,
+            "body": body,
+            "comments_url": comments_url,
+            "labels": [{"name": "codegen:request"}],
+            "pull_request": None,
+        },
+        "repository": {
+            "full_name": repo,
+        },
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--title", required=True)
+    parser.add_argument("--body", required=True)
+    parser.add_argument("--number", type=int, default=0)
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--comments-url")
+    parser.add_argument("--out", required=True)
+    args = parser.parse_args()
+
+    event = build_issue_event(
+        title=args.title,
+        body=args.body,
+        number=args.number,
+        repo=args.repo,
+        comments_url=args.comments_url,
+    )
+    Path(args.out).write_text(json.dumps(event, indent=2), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/aaz_dev_mcp/ci/find_preview.py
+++ b/src/aaz_dev_mcp/ci/find_preview.py
@@ -1,0 +1,73 @@
+"""Find the latest valid AAZ codegen preview comment for an issue."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+from .preview_issue_codegen import decode_state_from_comment
+
+
+def find_latest_preview(event: dict[str, Any], token: str) -> dict[str, Any]:
+    issue = event.get("issue") or {}
+    comments_url = issue.get("comments_url")
+    if not comments_url:
+        raise RuntimeError("Issue event did not contain comments_url.")
+
+    comments = _github_get_json(comments_url, token)
+    previews = []
+    for comment in comments:
+        state = decode_state_from_comment(comment.get("body") or "")
+        if not state:
+            continue
+        state["_comment_id"] = comment.get("id")
+        state["_comment_url"] = comment.get("html_url")
+        state["_comment_created_at"] = comment.get("created_at")
+        previews.append(state)
+
+    if not previews:
+        raise RuntimeError("No AAZ codegen preview comment was found.")
+    previews.sort(key=lambda item: item.get("_comment_created_at") or "")
+    latest = previews[-1]
+    if not latest.get("valid"):
+        raise RuntimeError("Latest AAZ codegen preview is not valid.")
+    return latest
+
+
+def _github_get_json(url: str, token: str) -> Any:
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--event", required=True)
+    parser.add_argument("--out", required=True)
+    args = parser.parse_args()
+
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if not token:
+        print("GH_TOKEN or GITHUB_TOKEN is required.", file=sys.stderr)
+        raise SystemExit(2)
+
+    event = json.loads(Path(args.event).read_text(encoding="utf-8"))
+    preview = find_latest_preview(event, token)
+    Path(args.out).write_text(json.dumps(preview, indent=2), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/src/aaz_dev_mcp/ci/issue_prompt.py
+++ b/src/aaz_dev_mcp/ci/issue_prompt.py
@@ -25,6 +25,7 @@ Schema:
   "api_version": string | null,
   "swagger_module": string | null,
   "cli_module": string | null,
+  "resource_paths": string[] | null,
   "target": "main" | "extension" | null,
   "profile": string | null,
   "spec_source": "main" | string | null,
@@ -39,6 +40,8 @@ Rules:
 - api_version must look like "2024-08-01" or "2024-08-01-preview".
 - swagger_module is the azure-rest-api-specs top-level module, for example "consumption".
 - cli_module is the azure-cli command module, often the same as swagger_module.
+- If the issue includes exact swagger resource paths, copy them verbatim into resource_paths.
+- If the issue does not include exact swagger resource paths, set resource_paths to null.
 - target defaults to "main" unless the issue clearly asks for an extension.
 - profile defaults to "latest".
 - spec_source defaults to "main" unless a branch or PR is explicitly requested.
@@ -89,4 +92,3 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
-

--- a/src/aaz_dev_mcp/ci/issue_prompt.py
+++ b/src/aaz_dev_mcp/ci/issue_prompt.py
@@ -1,0 +1,92 @@
+"""Build GitHub Models prompts from GitHub issue events."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+DEFAULT_MODEL = "openai/gpt-4o-mini"
+
+
+def build_prompt(event: dict) -> str:
+    issue = event.get("issue") or {}
+    title = issue.get("title") or ""
+    body = issue.get("body") or ""
+
+    return f"""Extract an AAZ Azure CLI code generation request from this GitHub issue.
+
+Return JSON only. Do not wrap it in Markdown.
+
+Schema:
+{{
+  "resource_provider": string | null,
+  "api_version": string | null,
+  "swagger_module": string | null,
+  "cli_module": string | null,
+  "target": "main" | "extension" | null,
+  "profile": string | null,
+  "spec_source": "main" | string | null,
+  "confidence": "high" | "medium" | "low",
+  "questions": string[],
+  "notes": string | null
+}}
+
+Rules:
+- resource_provider should be only the provider namespace, for example "Microsoft.Consumption".
+- If the issue says "Microsoft.Compute/disks", set resource_provider to "Microsoft.Compute".
+- api_version must look like "2024-08-01" or "2024-08-01-preview".
+- swagger_module is the azure-rest-api-specs top-level module, for example "consumption".
+- cli_module is the azure-cli command module, often the same as swagger_module.
+- target defaults to "main" unless the issue clearly asks for an extension.
+- profile defaults to "latest".
+- spec_source defaults to "main" unless a branch or PR is explicitly requested.
+- If required fields are missing, set them to null and add concise questions.
+- Never invent a resource provider or API version.
+
+Issue title:
+{title}
+
+Issue body:
+{body}
+"""
+
+
+def build_payload(event: dict, model: str) -> dict:
+    return {
+        "model": model,
+        "messages": [
+            {
+                "role": "system",
+                "content": (
+                    "You are a strict information extraction tool for Azure "
+                    "CLI AAZ code generation requests. Output valid JSON only."
+                ),
+            },
+            {"role": "user", "content": build_prompt(event)},
+        ],
+        "temperature": 0,
+        "max_tokens": 1200,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--event", required=True)
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--payload", action="store_true")
+    parser.add_argument("--model", default=DEFAULT_MODEL)
+    args = parser.parse_args()
+
+    event = json.loads(Path(args.event).read_text(encoding="utf-8"))
+    if args.payload:
+        data = build_payload(event, args.model)
+        Path(args.out).write_text(json.dumps(data, indent=2), encoding="utf-8")
+    else:
+        Path(args.out).write_text(build_prompt(event), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/src/aaz_dev_mcp/ci/preview_issue_codegen.py
+++ b/src/aaz_dev_mcp/ci/preview_issue_codegen.py
@@ -1,0 +1,244 @@
+"""Validate LLM-extracted issue requests and render preview comments."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .spec_discovery import (
+    discover_resources,
+    normalize_provider,
+    summarize_resources,
+    validate_api_version,
+)
+
+
+MARKER_PREFIX = "aaz-codegen-preview:v1:"
+
+
+def parse_llm_response(path: str | Path) -> dict[str, Any]:
+    raw = json.loads(Path(path).read_text(encoding="utf-8"))
+    content = None
+    if isinstance(raw, dict):
+        choices = raw.get("choices") or []
+        if choices:
+            content = ((choices[0].get("message") or {}).get("content"))
+        content = content or raw.get("response") or raw.get("content")
+    if not content:
+        raise ValueError("GitHub Models response did not contain message content.")
+    return _parse_json_content(content)
+
+
+def build_preview(
+    event: dict[str, Any],
+    extracted: dict[str, Any],
+    swagger_path: str | Path,
+) -> tuple[dict[str, Any], str]:
+    issue = event.get("issue") or {}
+    issue_number = issue.get("number")
+    errors: list[str] = []
+    questions: list[str] = [
+        str(q).strip()
+        for q in (extracted.get("questions") or [])
+        if str(q).strip()
+    ]
+
+    provider = normalize_provider(extracted.get("resource_provider"))
+    api_version = validate_api_version(extracted.get("api_version"))
+    swagger_module = _empty_to_none(extracted.get("swagger_module"))
+    cli_module = _empty_to_none(extracted.get("cli_module"))
+    target = _empty_to_none(extracted.get("target")) or "main"
+    profile = _empty_to_none(extracted.get("profile")) or "latest"
+    spec_source = _empty_to_none(extracted.get("spec_source")) or "main"
+
+    if not provider:
+        errors.append("Could not extract a resource provider.")
+        questions.append("Which Azure resource provider should be generated?")
+    if not api_version:
+        errors.append("Could not extract a valid API version.")
+        questions.append("Which API version should be generated?")
+    if target not in {"main", "extension"}:
+        errors.append(f"Unsupported target `{target}`. Use `main` or `extension`.")
+    elif target == "extension":
+        errors.append("Extension target is not supported by the v1 GitHub Actions runner.")
+    if spec_source != "main":
+        errors.append(
+            "Only `azure-rest-api-specs` main is supported in v1. "
+            f"Requested spec source: `{spec_source}`."
+        )
+
+    discovery = None
+    if provider and api_version and spec_source == "main":
+        discovery = discover_resources(
+            swagger_path=swagger_path,
+            resource_provider=provider,
+            api_version=api_version,
+            swagger_module=swagger_module,
+        )
+        errors.extend(discovery.errors)
+        if not swagger_module and len(discovery.modules) == 1:
+            swagger_module = discovery.modules[0]
+        if not cli_module and swagger_module:
+            cli_module = swagger_module
+
+    if not swagger_module:
+        errors.append("Could not infer the swagger module.")
+        questions.append("Which azure-rest-api-specs module should be used?")
+    if not cli_module:
+        errors.append("Could not infer the Azure CLI module.")
+        questions.append("Which azure-cli command module should be generated?")
+
+    resources = discovery.resources if discovery else []
+    request = {
+        "resource_provider": provider,
+        "api_version": api_version,
+        "swagger_module": swagger_module,
+        "cli_module": cli_module,
+        "target": target,
+        "profile": profile,
+        "spec_source": spec_source,
+        "confidence": extracted.get("confidence") or "low",
+        "notes": extracted.get("notes"),
+    }
+    valid = not errors and bool(resources)
+    state = {
+        "schema": "aaz-codegen-preview/v1",
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "issue_number": issue_number,
+        "valid": valid,
+        "request": request,
+        "resource_count": len(resources),
+        "resource_hash": discovery.resource_hash if discovery else None,
+        "errors": _dedupe(errors),
+        "questions": _dedupe(questions),
+    }
+    return state, render_preview_markdown(state, resources)
+
+
+def render_preview_markdown(state: dict[str, Any], resources: list[Any]) -> str:
+    marker = encode_state_marker(state)
+    request = state["request"]
+    lines = [
+        marker,
+        "## AAZ Codegen Preview",
+        "",
+        f"Status: **{'ready' if state['valid'] else 'needs clarification'}**",
+        "",
+        "| Field | Value |",
+        "| --- | --- |",
+    ]
+    for key in [
+        "resource_provider",
+        "api_version",
+        "swagger_module",
+        "cli_module",
+        "target",
+        "profile",
+        "spec_source",
+        "confidence",
+    ]:
+        value = request.get(key)
+        lines.append(f"| `{key}` | `{value or ''}` |")
+
+    if state["errors"]:
+        lines.extend(["", "### Blocking Issues"])
+        lines.extend(f"- {err}" for err in state["errors"])
+    if state["questions"]:
+        lines.extend(["", "### Questions"])
+        lines.extend(f"- {question}" for question in state["questions"])
+
+    lines.extend(
+        [
+            "",
+            "### Discovered Resources",
+            "",
+            summarize_resources(resources),
+            "",
+        ]
+    )
+    if state["valid"]:
+        lines.append("Comment `/codegen` on this issue to run codegen from this preview.")
+    else:
+        lines.append("Update the issue with the missing details, then re-run the preview by editing the issue or reapplying `codegen:request`.")
+    return "\n".join(lines) + "\n"
+
+
+def encode_state_marker(state: dict[str, Any]) -> str:
+    data = json.dumps(state, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return f"<!-- {MARKER_PREFIX}{base64.b64encode(data).decode('ascii')} -->"
+
+
+def decode_state_from_comment(body: str) -> dict[str, Any] | None:
+    pattern = re.compile(r"<!--\s*" + re.escape(MARKER_PREFIX) + r"([A-Za-z0-9+/=]+)\s*-->")
+    match = pattern.search(body or "")
+    if not match:
+        return None
+    try:
+        data = base64.b64decode(match.group(1)).decode("utf-8")
+        state = json.loads(data)
+    except (ValueError, json.JSONDecodeError):
+        return None
+    if state.get("schema") != "aaz-codegen-preview/v1":
+        return None
+    return state
+
+
+def _parse_json_content(content: str) -> dict[str, Any]:
+    content = content.strip()
+    if content.startswith("```"):
+        content = re.sub(r"^```(?:json)?\s*", "", content)
+        content = re.sub(r"\s*```$", "", content)
+    try:
+        result = json.loads(content)
+    except json.JSONDecodeError:
+        match = re.search(r"\{.*\}", content, flags=re.DOTALL)
+        if not match:
+            raise
+        result = json.loads(match.group(0))
+    if not isinstance(result, dict):
+        raise ValueError("LLM extraction response must be a JSON object.")
+    return result
+
+
+def _empty_to_none(value: Any) -> str | None:
+    if value is None:
+        return None
+    value = str(value).strip()
+    if not value or value.upper() == "N/A" or value.lower() == "null":
+        return None
+    return value
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    seen = set()
+    result = []
+    for value in values:
+        if value not in seen:
+            result.append(value)
+            seen.add(value)
+    return result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--event", required=True)
+    parser.add_argument("--llm-response", required=True)
+    parser.add_argument("--swagger-path", required=True)
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--state", required=True)
+    args = parser.parse_args()
+
+    event = json.loads(Path(args.event).read_text(encoding="utf-8"))
+    extracted = parse_llm_response(args.llm_response)
+    state, markdown = build_preview(event, extracted, args.swagger_path)
+    Path(args.out).write_text(markdown, encoding="utf-8")
+    Path(args.state).write_text(json.dumps(state, indent=2), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/aaz_dev_mcp/ci/preview_issue_codegen.py
+++ b/src/aaz_dev_mcp/ci/preview_issue_codegen.py
@@ -52,6 +52,9 @@ def build_preview(
     api_version = validate_api_version(extracted.get("api_version"))
     swagger_module = _empty_to_none(extracted.get("swagger_module"))
     cli_module = _empty_to_none(extracted.get("cli_module"))
+    resource_paths = _normalize_resource_paths(extracted.get("resource_paths"))
+    if not resource_paths:
+        resource_paths = _extract_resource_paths_from_text(issue.get("body"), provider)
     target = _empty_to_none(extracted.get("target")) or "main"
     profile = _empty_to_none(extracted.get("profile")) or "latest"
     spec_source = _empty_to_none(extracted.get("spec_source")) or "main"
@@ -79,6 +82,7 @@ def build_preview(
             resource_provider=provider,
             api_version=api_version,
             swagger_module=swagger_module,
+            resource_paths=resource_paths,
         )
         errors.extend(discovery.errors)
         if not swagger_module and len(discovery.modules) == 1:
@@ -99,6 +103,7 @@ def build_preview(
         "api_version": api_version,
         "swagger_module": swagger_module,
         "cli_module": cli_module,
+        "resource_paths": resource_paths or None,
         "target": target,
         "profile": profile,
         "spec_source": spec_source,
@@ -137,13 +142,14 @@ def render_preview_markdown(state: dict[str, Any], resources: list[Any]) -> str:
         "api_version",
         "swagger_module",
         "cli_module",
+        "resource_paths",
         "target",
         "profile",
         "spec_source",
         "confidence",
     ]:
         value = request.get(key)
-        lines.append(f"| `{key}` | `{value or ''}` |")
+        lines.append(f"| `{key}` | {_format_table_value(value)} |")
 
     if state["errors"]:
         lines.extend(["", "### Blocking Issues"])
@@ -212,6 +218,39 @@ def _empty_to_none(value: Any) -> str | None:
     if not value or value.upper() == "N/A" or value.lower() == "null":
         return None
     return value
+
+
+def _normalize_resource_paths(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        values = [value]
+    else:
+        values = list(value) if isinstance(value, list) else []
+    return [
+        path
+        for path in (str(item).strip().strip("`") for item in values)
+        if path
+    ]
+
+
+def _extract_resource_paths_from_text(text: Any, provider: str | None) -> list[str]:
+    if not text:
+        return []
+    provider_lower = provider.lower() if provider else None
+    paths = []
+    for match in re.finditer(r"/[A-Za-z0-9{}._~:/?&=%+-]+", str(text)):
+        path = match.group(0).rstrip(".,;:")
+        if provider_lower and provider_lower not in path.lower():
+            continue
+        paths.append(path)
+    return _dedupe(paths)
+
+
+def _format_table_value(value: Any) -> str:
+    if isinstance(value, list):
+        return "<br>".join(f"`{item}`" for item in value)
+    return f"`{value or ''}`"
 
 
 def _dedupe(values: list[str]) -> list[str]:

--- a/src/aaz_dev_mcp/ci/run_issue_codegen.py
+++ b/src/aaz_dev_mcp/ci/run_issue_codegen.py
@@ -26,6 +26,7 @@ def run_codegen_from_preview(
         resource_provider=request["resource_provider"],
         api_version=request["api_version"],
         swagger_module=request["swagger_module"],
+        resource_paths=request.get("resource_paths"),
     )
     if discovery.errors:
         raise RuntimeError("; ".join(discovery.errors))
@@ -158,4 +159,3 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
-

--- a/src/aaz_dev_mcp/ci/run_issue_codegen.py
+++ b/src/aaz_dev_mcp/ci/run_issue_codegen.py
@@ -15,10 +15,11 @@ def run_codegen_from_preview(
     preview: dict[str, Any],
     swagger_path: str,
     aaz_path: str,
-    cli_path: str,
+    cli_path: str | None,
     cli_extension_path: str | None,
     workspace_folder: str,
     by_patch: bool,
+    skip_cli: bool = False,
 ) -> dict[str, Any]:
     request = preview["request"]
     discovery = discover_resources(
@@ -70,13 +71,14 @@ def run_codegen_from_preview(
         api_version=request["api_version"],
     )
     workspaces.generate_to_aaz(workspace_name)
-    modules.select_command_versions(
-        target=request.get("target") or "main",
-        module_name=request["cli_module"],
-        profile=request.get("profile") or "latest",
-        command_versions=command_versions,
-        by_patch=by_patch,
-    )
+    if not skip_cli:
+        modules.select_command_versions(
+            target=request.get("target") or "main",
+            module_name=request["cli_module"],
+            profile=request.get("profile") or "latest",
+            command_versions=command_versions,
+            by_patch=by_patch,
+        )
     return {
         "workspace": workspace_name,
         "request": request,
@@ -84,6 +86,7 @@ def run_codegen_from_preview(
         "command_count": len(command_versions),
         "commands": sorted(command_versions.keys()),
         "by_patch": by_patch,
+        "cli_generated": not skip_cli,
     }
 
 
@@ -102,6 +105,7 @@ def render_summary(result: dict[str, Any]) -> str:
         f"- Resources: `{result['resource_count']}`",
         f"- Commands: `{result['command_count']}`",
         f"- by_patch: `{result['by_patch']}`",
+        f"- Azure CLI generated: `{result['cli_generated']}`",
         "",
         "### Commands",
     ]
@@ -135,12 +139,13 @@ def main() -> None:
     parser.add_argument("--preview", required=True)
     parser.add_argument("--swagger-path", required=True)
     parser.add_argument("--aaz-path", required=True)
-    parser.add_argument("--cli-path", required=True)
+    parser.add_argument("--cli-path")
     parser.add_argument("--cli-extension-path")
     parser.add_argument("--workspace-folder", required=True)
     parser.add_argument("--summary", required=True)
     parser.add_argument("--json-out", required=True)
     parser.add_argument("--by-patch", choices=["true", "false"], default="true")
+    parser.add_argument("--skip-cli", choices=["true", "false"], default="false")
     args = parser.parse_args()
 
     preview = json.loads(Path(args.preview).read_text(encoding="utf-8"))
@@ -152,6 +157,7 @@ def main() -> None:
         cli_extension_path=args.cli_extension_path,
         workspace_folder=args.workspace_folder,
         by_patch=args.by_patch == "true",
+        skip_cli=args.skip_cli == "true",
     )
     Path(args.summary).write_text(render_summary(result), encoding="utf-8")
     Path(args.json_out).write_text(json.dumps(result, indent=2), encoding="utf-8")

--- a/src/aaz_dev_mcp/ci/run_issue_codegen.py
+++ b/src/aaz_dev_mcp/ci/run_issue_codegen.py
@@ -1,0 +1,161 @@
+"""Run deterministic AAZ codegen from a validated issue preview."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from .spec_discovery import discover_resources
+
+
+def run_codegen_from_preview(
+    preview: dict[str, Any],
+    swagger_path: str,
+    aaz_path: str,
+    cli_path: str,
+    cli_extension_path: str | None,
+    workspace_folder: str,
+    by_patch: bool,
+) -> dict[str, Any]:
+    request = preview["request"]
+    discovery = discover_resources(
+        swagger_path=swagger_path,
+        resource_provider=request["resource_provider"],
+        api_version=request["api_version"],
+        swagger_module=request["swagger_module"],
+    )
+    if discovery.errors:
+        raise RuntimeError("; ".join(discovery.errors))
+    if preview.get("resource_hash") and discovery.resource_hash != preview["resource_hash"]:
+        raise RuntimeError(
+            "Discovered resources changed since preview. Re-run codegen preview first."
+        )
+
+    from aaz_dev_mcp.config import apply_config
+    from aaz_dev_mcp.services.cli import modules
+    from aaz_dev_mcp.services.command import workspaces
+
+    apply_config(
+        aaz_path=aaz_path,
+        swagger_path=swagger_path,
+        cli_path=cli_path,
+        cli_extension_path=cli_extension_path,
+        workspace_folder=workspace_folder,
+    )
+
+    workspace_name = _workspace_name(
+        issue_number=preview.get("issue_number"),
+        provider=request["resource_provider"],
+        api_version=request["api_version"],
+    )
+    workspaces.create_workspace(
+        name=workspace_name,
+        plane="mgmt-plane",
+        mod_names=request["swagger_module"],
+        resource_provider=request["resource_provider"],
+        source="OpenAPI",
+    )
+    workspaces.add_swagger_resources(
+        name=workspace_name,
+        module=request["swagger_module"],
+        version=request["api_version"],
+        resource_paths=discovery.resource_paths,
+    )
+    command_versions = _workspace_command_versions(
+        workspace_name=workspace_name,
+        api_version=request["api_version"],
+    )
+    workspaces.generate_to_aaz(workspace_name)
+    modules.select_command_versions(
+        target=request.get("target") or "main",
+        module_name=request["cli_module"],
+        profile=request.get("profile") or "latest",
+        command_versions=command_versions,
+        by_patch=by_patch,
+    )
+    return {
+        "workspace": workspace_name,
+        "request": request,
+        "resource_count": len(discovery.resources),
+        "command_count": len(command_versions),
+        "commands": sorted(command_versions.keys()),
+        "by_patch": by_patch,
+    }
+
+
+def render_summary(result: dict[str, Any]) -> str:
+    request = result["request"]
+    lines = [
+        "## AAZ Codegen Run",
+        "",
+        f"- Workspace: `{result['workspace']}`",
+        f"- Resource provider: `{request['resource_provider']}`",
+        f"- API version: `{request['api_version']}`",
+        f"- Swagger module: `{request['swagger_module']}`",
+        f"- CLI module: `{request['cli_module']}`",
+        f"- Target: `{request.get('target') or 'main'}`",
+        f"- Profile: `{request.get('profile') or 'latest'}`",
+        f"- Resources: `{result['resource_count']}`",
+        f"- Commands: `{result['command_count']}`",
+        f"- by_patch: `{result['by_patch']}`",
+        "",
+        "### Commands",
+    ]
+    lines.extend(f"- `{command}`" for command in result["commands"])
+    return "\n".join(lines) + "\n"
+
+
+def _workspace_command_versions(workspace_name: str, api_version: str) -> dict[str, str]:
+    import aaz_dev  # noqa: F401
+    from command.controller.workspace_manager import WorkspaceManager
+
+    manager = WorkspaceManager(workspace_name)
+    manager.load()
+    command_versions = {}
+    for leaf in manager.iter_command_tree_leaves():
+        command_versions[" ".join(leaf.names)] = api_version
+    if not command_versions:
+        raise RuntimeError("Workspace did not produce any command leaves.")
+    return command_versions
+
+
+def _workspace_name(issue_number: int | None, provider: str, api_version: str) -> str:
+    prefix = f"issue-{issue_number}-" if issue_number else ""
+    text = f"{prefix}{provider}-{api_version}".lower()
+    text = re.sub(r"[^a-z0-9._-]+", "-", text)
+    return text.strip("-")[:80]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--preview", required=True)
+    parser.add_argument("--swagger-path", required=True)
+    parser.add_argument("--aaz-path", required=True)
+    parser.add_argument("--cli-path", required=True)
+    parser.add_argument("--cli-extension-path")
+    parser.add_argument("--workspace-folder", required=True)
+    parser.add_argument("--summary", required=True)
+    parser.add_argument("--json-out", required=True)
+    parser.add_argument("--by-patch", choices=["true", "false"], default="true")
+    args = parser.parse_args()
+
+    preview = json.loads(Path(args.preview).read_text(encoding="utf-8"))
+    result = run_codegen_from_preview(
+        preview=preview,
+        swagger_path=args.swagger_path,
+        aaz_path=args.aaz_path,
+        cli_path=args.cli_path,
+        cli_extension_path=args.cli_extension_path,
+        workspace_folder=args.workspace_folder,
+        by_patch=args.by_patch == "true",
+    )
+    Path(args.summary).write_text(render_summary(result), encoding="utf-8")
+    Path(args.json_out).write_text(json.dumps(result, indent=2), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/src/aaz_dev_mcp/ci/spec_discovery.py
+++ b/src/aaz_dev_mcp/ci/spec_discovery.py
@@ -196,6 +196,8 @@ def _read_swagger_resources(
     for path in sorted(paths):
         if provider_lower not in path.lower():
             continue
+        if _is_provider_operations_path(path, provider):
+            continue
         resources.append(
             DiscoveredResource(
                 module=module,
@@ -206,3 +208,8 @@ def _read_swagger_resources(
             )
         )
     return resources
+
+
+def _is_provider_operations_path(path: str, provider: str) -> bool:
+    path = path.split("?", maxsplit=1)[0].rstrip("/")
+    return path.lower() == f"/providers/{provider.lower()}/operations"

--- a/src/aaz_dev_mcp/ci/spec_discovery.py
+++ b/src/aaz_dev_mcp/ci/spec_discovery.py
@@ -67,6 +67,7 @@ def discover_resources(
     resource_provider: str,
     api_version: str,
     swagger_module: str | None = None,
+    resource_paths: Iterable[str] | None = None,
 ) -> DiscoveryResult:
     """Find swagger paths for a provider and API version.
 
@@ -91,6 +92,7 @@ def discover_resources(
         errors.append(f"Invalid API version: {api_version!r}")
     if errors:
         return DiscoveryResult(resources=[], modules=[], errors=errors)
+    requested_paths = _normalize_resource_paths(resource_paths)
 
     provider_dirs = _find_provider_dirs(spec_root, provider, swagger_module)
     if not provider_dirs:
@@ -112,6 +114,7 @@ def discover_resources(
                     module=module,
                     provider=provider,
                     api_version=version,
+                    requested_paths=requested_paths,
                 )
             )
 
@@ -122,14 +125,20 @@ def discover_resources(
             f"`{swagger_module}`: {', '.join(modules)}"
         )
     if not resources:
-        errors.append(
-            f"No OpenAPI resources found for `{provider}` at `{version}`."
-        )
+        errors.append(f"No OpenAPI resources found for `{provider}` at `{version}`.")
     elif not swagger_module and len(modules) > 1:
         errors.append(
             "Provider/version matched multiple swagger modules: "
             + ", ".join(f"`{m}`" for m in modules)
         )
+    if requested_paths:
+        discovered_paths = {r.path for r in resources}
+        missing_paths = sorted(requested_paths - discovered_paths)
+        if missing_paths:
+            errors.append(
+                "Requested swagger resource paths were not found: "
+                + ", ".join(f"`{p}`" for p in missing_paths)
+            )
 
     return DiscoveryResult(
         resources=sorted(
@@ -177,6 +186,7 @@ def _read_swagger_resources(
     module: str,
     provider: str,
     api_version: str,
+    requested_paths: set[str],
 ) -> list[DiscoveredResource]:
     try:
         body = json.loads(json_file.read_text(encoding="utf-8"))
@@ -194,6 +204,8 @@ def _read_swagger_resources(
     provider_lower = provider.lower()
     resources = []
     for path in sorted(paths):
+        if requested_paths and path not in requested_paths:
+            continue
         if provider_lower not in path.lower():
             continue
         if _is_provider_operations_path(path, provider):
@@ -213,3 +225,13 @@ def _read_swagger_resources(
 def _is_provider_operations_path(path: str, provider: str) -> bool:
     path = path.split("?", maxsplit=1)[0].rstrip("/")
     return path.lower() == f"/providers/{provider.lower()}/operations"
+
+
+def _normalize_resource_paths(resource_paths: Iterable[str] | None) -> set[str]:
+    if not resource_paths:
+        return set()
+    return {
+        str(path).strip().strip("`")
+        for path in resource_paths
+        if str(path).strip()
+    }

--- a/src/aaz_dev_mcp/ci/spec_discovery.py
+++ b/src/aaz_dev_mcp/ci/spec_discovery.py
@@ -1,0 +1,208 @@
+"""Lightweight OpenAPI resource discovery for issue-driven codegen."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+PROVIDER_RE = re.compile(
+    r"Microsoft\.[A-Za-z0-9]+(?:[A-Za-z0-9_.-]*[A-Za-z0-9])?",
+    re.IGNORECASE,
+)
+API_VERSION_RE = re.compile(r"^\d{4}-\d{2}-\d{2}(?:-[A-Za-z0-9-]+)?$")
+
+
+@dataclass(frozen=True)
+class DiscoveredResource:
+    module: str
+    provider: str
+    api_version: str
+    file_path: str
+    path: str
+
+
+@dataclass(frozen=True)
+class DiscoveryResult:
+    resources: list[DiscoveredResource]
+    modules: list[str]
+    errors: list[str]
+
+    @property
+    def resource_paths(self) -> list[str]:
+        return sorted({r.path for r in self.resources})
+
+    @property
+    def resource_hash(self) -> str:
+        joined = "\n".join(self.resource_paths)
+        return hashlib.sha256(joined.encode("utf-8")).hexdigest()
+
+
+def normalize_provider(value: str | None) -> str | None:
+    if not value:
+        return None
+    value = value.strip().strip("`")
+    match = PROVIDER_RE.search(value)
+    if not match:
+        return value or None
+    provider = match.group(0)
+    if provider.lower().startswith("microsoft."):
+        provider = "Microsoft." + provider.split(".", 1)[1]
+    return provider
+
+
+def validate_api_version(value: str | None) -> str | None:
+    if not value:
+        return None
+    value = value.strip().strip("`")
+    return value if API_VERSION_RE.match(value) else None
+
+
+def discover_resources(
+    swagger_path: str | Path,
+    resource_provider: str,
+    api_version: str,
+    swagger_module: str | None = None,
+) -> DiscoveryResult:
+    """Find swagger paths for a provider and API version.
+
+    This intentionally avoids importing the full aaz-dev swagger model layer so
+    the preview workflow can cheaply validate issue text before codegen.
+    """
+    swagger_root = Path(swagger_path)
+    spec_root = swagger_root / "specification"
+    errors: list[str] = []
+    if not spec_root.is_dir():
+        return DiscoveryResult(
+            resources=[],
+            modules=[],
+            errors=[f"Swagger specification folder not found: {spec_root}"],
+        )
+
+    provider = normalize_provider(resource_provider)
+    version = validate_api_version(api_version)
+    if not provider:
+        errors.append("Missing or invalid resource provider.")
+    if not version:
+        errors.append(f"Invalid API version: {api_version!r}")
+    if errors:
+        return DiscoveryResult(resources=[], modules=[], errors=errors)
+
+    provider_dirs = _find_provider_dirs(spec_root, provider, swagger_module)
+    if not provider_dirs:
+        module_text = f" in module `{swagger_module}`" if swagger_module else ""
+        return DiscoveryResult(
+            resources=[],
+            modules=[],
+            errors=[f"Resource provider `{provider}` not found{module_text}."],
+        )
+
+    resources: list[DiscoveredResource] = []
+    for provider_dir in provider_dirs:
+        module = provider_dir.relative_to(spec_root).parts[0]
+        for json_file in provider_dir.rglob("*.json"):
+            resources.extend(
+                _read_swagger_resources(
+                    json_file=json_file,
+                    spec_root=spec_root,
+                    module=module,
+                    provider=provider,
+                    api_version=version,
+                )
+            )
+
+    modules = sorted({r.module for r in resources})
+    if swagger_module and modules and modules != [swagger_module]:
+        errors.append(
+            "Discovered resources outside requested module "
+            f"`{swagger_module}`: {', '.join(modules)}"
+        )
+    if not resources:
+        errors.append(
+            f"No OpenAPI resources found for `{provider}` at `{version}`."
+        )
+    elif not swagger_module and len(modules) > 1:
+        errors.append(
+            "Provider/version matched multiple swagger modules: "
+            + ", ".join(f"`{m}`" for m in modules)
+        )
+
+    return DiscoveryResult(
+        resources=sorted(
+            resources,
+            key=lambda r: (r.module, r.file_path, r.path),
+        ),
+        modules=modules,
+        errors=errors,
+    )
+
+
+def summarize_resources(resources: Iterable[DiscoveredResource], limit: int = 80) -> str:
+    rows = []
+    for idx, resource in enumerate(resources):
+        if idx >= limit:
+            rows.append(f"- ... truncated after {limit} resources")
+            break
+        rows.append(f"- `{resource.path}`")
+    return "\n".join(rows) if rows else "_No resources discovered._"
+
+
+def _find_provider_dirs(
+    spec_root: Path,
+    resource_provider: str,
+    swagger_module: str | None,
+) -> list[Path]:
+    roots = [spec_root / swagger_module] if swagger_module else spec_root.iterdir()
+    provider_lower = resource_provider.lower()
+    matches: list[Path] = []
+    for root in roots:
+        if not root.is_dir():
+            continue
+        resource_manager = root / "resource-manager"
+        if not resource_manager.is_dir():
+            continue
+        for path in resource_manager.rglob("*"):
+            if path.is_dir() and path.name.lower() == provider_lower:
+                matches.append(path)
+    return sorted(set(matches))
+
+
+def _read_swagger_resources(
+    json_file: Path,
+    spec_root: Path,
+    module: str,
+    provider: str,
+    api_version: str,
+) -> list[DiscoveredResource]:
+    try:
+        body = json.loads(json_file.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return []
+
+    if body.get("swagger") != "2.0":
+        return []
+    if body.get("info", {}).get("version") != api_version:
+        return []
+
+    paths = set()
+    paths.update((body.get("paths") or {}).keys())
+    paths.update((body.get("x-ms-paths") or {}).keys())
+    provider_lower = provider.lower()
+    resources = []
+    for path in sorted(paths):
+        if provider_lower not in path.lower():
+            continue
+        resources.append(
+            DiscoveredResource(
+                module=module,
+                provider=provider,
+                api_version=api_version,
+                file_path=str(json_file.relative_to(spec_root)),
+                path=path,
+            )
+        )
+    return resources

--- a/src/aaz_dev_mcp/config.py
+++ b/src/aaz_dev_mcp/config.py
@@ -1,0 +1,61 @@
+"""Path configuration helpers.
+
+The aaz-dev-tools backend reads paths from a global :class:`utils.config.Config`
+class. This module exposes a single :func:`apply_config` that mutates those
+class attributes, surfacing the validating setters' ``ValueError`` to the
+caller (the MCP ``configure`` tool).
+
+Environment variables already honored by the upstream Config at import time:
+    AAZ_PATH                  -> aaz repo checkout
+    AAZ_SWAGGER_PATH          -> azure-rest-api-specs checkout
+    AAZ_CLI_PATH              -> azure-cli checkout
+    AAZ_CLI_EXTENSION_PATH    -> azure-cli-extensions checkout
+    AAZ_DEV_WORKSPACE_FOLDER  -> where ws.json files live (default ~/.aaz/workspaces)
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+# Importing ``aaz_dev`` first injects ``src/aaz_dev`` onto sys.path (see its
+# __init__.py), which makes the bare-namespace ``utils``/``command``/``cli``/
+# ``swagger`` imports used throughout the backend resolvable.
+import aaz_dev  # noqa: F401
+from utils.config import Config
+
+
+def apply_config(
+    aaz_path: Optional[str] = None,
+    swagger_path: Optional[str] = None,
+    cli_path: Optional[str] = None,
+    cli_extension_path: Optional[str] = None,
+    workspace_folder: Optional[str] = None,
+) -> dict:
+    """Update Config in place. Returns the resulting paths.
+
+    Each setter validates that the path exists and raises ``ValueError``
+    otherwise; the caller (MCP tool) should turn that into a tool error.
+    """
+    # The setters use Click's callback signature (cls, ctx, param, value).
+    # We pass None for ctx/param since we're not in a Click context.
+    if aaz_path is not None:
+        Config.validate_and_setup_aaz_path(None, None, aaz_path)
+    if swagger_path is not None:
+        Config.validate_and_setup_swagger_path(None, None, swagger_path)
+    if cli_path is not None:
+        Config.validate_and_setup_cli_path(None, None, cli_path)
+    if cli_extension_path is not None:
+        Config.validate_and_setup_cli_extension_path(None, None, cli_extension_path)
+    if workspace_folder is not None:
+        Config.validate_and_setup_aaz_dev_workspace_folder(None, None, workspace_folder)
+    return current_config()
+
+
+def current_config() -> dict:
+    return {
+        "aaz_path": Config.AAZ_PATH,
+        "swagger_path": Config.SWAGGER_PATH,
+        "cli_path": Config.CLI_PATH,
+        "cli_extension_path": Config.CLI_EXTENSION_PATH,
+        "workspace_folder": Config.AAZ_DEV_WORKSPACE_FOLDER,
+    }

--- a/src/aaz_dev_mcp/pyproject.toml
+++ b/src/aaz_dev_mcp/pyproject.toml
@@ -1,0 +1,35 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "aaz-dev-mcp"
+version = "0.1.0"
+description = "Model Context Protocol server for aaz-dev-tools (Azure CLI code generation)."
+readme = "README.md"
+requires-python = ">=3.10"
+authors = [{ name = "aaz-dev-tools contributors" }]
+license = { text = "MIT" }
+dependencies = [
+    # MCP Python SDK (provides FastMCP + stdio transport)
+    "mcp>=1.0",
+    # The MCP imports aaz-dev controllers directly. The parent project must
+    # already be installed in the same environment (`pip install -e .` at repo
+    # root). We do NOT declare it as a path dependency here to keep this
+    # package installable from any working directory.
+]
+
+[project.scripts]
+aaz-dev-mcp = "aaz_dev_mcp.server:main"
+
+[tool.setuptools]
+package-dir = {"aaz_dev_mcp" = "."}
+packages = [
+    "aaz_dev_mcp",
+    "aaz_dev_mcp.services",
+    "aaz_dev_mcp.services.command",
+    "aaz_dev_mcp.services.cli",
+    "aaz_dev_mcp.tools",
+    "aaz_dev_mcp.tools.command",
+    "aaz_dev_mcp.tools.cli",
+]

--- a/src/aaz_dev_mcp/pyproject.toml
+++ b/src/aaz_dev_mcp/pyproject.toml
@@ -26,6 +26,7 @@ aaz-dev-mcp = "aaz_dev_mcp.server:main"
 package-dir = {"aaz_dev_mcp" = "."}
 packages = [
     "aaz_dev_mcp",
+    "aaz_dev_mcp.ci",
     "aaz_dev_mcp.services",
     "aaz_dev_mcp.services.command",
     "aaz_dev_mcp.services.cli",

--- a/src/aaz_dev_mcp/server.py
+++ b/src/aaz_dev_mcp/server.py
@@ -1,0 +1,38 @@
+"""FastMCP server entrypoint for aaz-dev-mcp.
+
+Run via the ``aaz-dev-mcp`` console script (installed by pyproject) or with
+``python -m aaz_dev_mcp.server``.
+
+The server speaks the Model Context Protocol over stdio. All log output goes
+to stderr so it doesn't corrupt the JSON-RPC stream on stdout.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+
+
+def _configure_logging() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        stream=sys.stderr,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+
+def main() -> None:
+    _configure_logging()
+
+    # Import lazily so logging is set up before any aaz-dev module logs.
+    from mcp.server.fastmcp import FastMCP
+    from .tools import register_tools
+
+    mcp = FastMCP("aaz-dev")
+    register_tools(mcp)
+    # FastMCP.run() defaults to stdio transport.
+    mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/aaz_dev_mcp/services/cli/modules.py
+++ b/src/aaz_dev_mcp/services/cli/modules.py
@@ -1,0 +1,142 @@
+"""CLI module operations: wraps AzMainManager / AzExtensionManager."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Optional
+
+import aaz_dev  # noqa: F401  (injects src/aaz_dev onto sys.path)
+from cli.controller.az_module_manager import AzMainManager, AzExtensionManager
+from cli.model.view import CLIModule
+from utils import exceptions
+
+
+def _manager(target: str):
+    if target == "main":
+        return AzMainManager()
+    if target == "extension":
+        return AzExtensionManager()
+    raise exceptions.InvalidAPIUsage(
+        f"target must be 'main' or 'extension', got {target!r}")
+
+
+def get_module(target: str, module_name: str) -> dict:
+    """Load the CLI view of a module (the current profile/command tree)."""
+    mgr = _manager(target)
+    module = mgr.load_module(module_name)
+    return module.to_primitive()
+
+
+def update_module(
+    target: str,
+    module_name: str,
+    profiles: Mapping[str, Any],
+    by_patch: bool = True,
+) -> dict:
+    """Generate CLI code for a module.
+
+    ``profiles`` is the same shape the Flask PUT/PATCH route consumes; e.g.::
+
+        {
+          "latest": {
+            "name": "latest",
+            "commandGroups": {
+              "consumption": {
+                "names": ["consumption"],
+                "commandGroups": {
+                  "budget": {
+                    "names": ["consumption", "budget"],
+                    "commands": {
+                      "create": {
+                        "names": ["consumption", "budget", "create"],
+                        "registered": true,
+                        "version": "2024-08-01"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+
+    ``by_patch=True`` (default) merges with the existing module instead of
+    overwriting; that matches the PATCH route the UI uses.
+    """
+    mgr = _manager(target)
+    module = CLIModule({"name": module_name, "profiles": profiles})
+    module = mgr.update_module(module_name, module.profiles, by_patch=by_patch)
+    return module.to_primitive()
+
+
+def select_command_versions(
+    target: str,
+    module_name: str,
+    profile: str,
+    command_versions: Mapping[str, str],
+    by_patch: bool = True,
+) -> dict:
+    """Higher-level helper: pick a version for each named command and
+    generate code.
+
+    ``command_versions`` maps space-separated command paths (without the leaf
+    being a wait command) to their desired API version, e.g.::
+
+        {
+            "consumption budget create": "2024-08-01",
+            "consumption budget delete": "2024-08-01",
+        }
+
+    All commands are marked ``registered=True``. The resulting profile is
+    passed to :func:`update_module` with ``by_patch=True`` so untouched
+    commands in the module are preserved.
+    """
+    command_groups: dict = {}
+    for cmd_path, version in command_versions.items():
+        parts = cmd_path.strip().split()
+        if len(parts) < 2:
+            raise exceptions.InvalidAPIUsage(
+                f"command path must have at least one group + leaf: {cmd_path!r}")
+        group_names = parts[:-1]
+        leaf_name = parts[-1]
+
+        cur = command_groups
+        for depth, name in enumerate(group_names, start=1):
+            full_names = parts[: depth]
+            if name not in cur:
+                cur[name] = {
+                    "names": full_names,
+                    "commandGroups": {},
+                    "commands": {},
+                }
+            cur = cur[name]
+            # descend into the nested commandGroups dict for next iteration
+            if depth < len(group_names):
+                cur = cur["commandGroups"]
+
+        cur.setdefault("commands", {})[leaf_name] = {
+            "names": parts,
+            "registered": True,
+            "version": version,
+        }
+
+    # prune empty commandGroups/commands placeholders for cleanliness
+    _prune(command_groups)
+
+    profiles = {
+        profile: {
+            "name": profile,
+            "commandGroups": command_groups,
+        }
+    }
+    return update_module(target, module_name, profiles, by_patch=by_patch)
+
+
+def _prune(groups: dict) -> None:
+    for group in groups.values():
+        sub = group.get("commandGroups")
+        if sub:
+            _prune(sub)
+        if sub == {} or sub is None:
+            group.pop("commandGroups", None)
+        if not group.get("commands"):
+            group.pop("commands", None)

--- a/src/aaz_dev_mcp/services/command/arguments.py
+++ b/src/aaz_dev_mcp/services/command/arguments.py
@@ -1,0 +1,156 @@
+"""Argument editing on workspace command leaves.
+
+Mirrors backend ``command/controller/workspace_cfg_editor.py`` argument
+operations: patch, flatten, unflatten.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import aaz_dev  # noqa: F401  (injects src/aaz_dev onto sys.path)
+from command.controller.workspace_manager import WorkspaceManager
+from utils import exceptions
+
+
+def _load_cfg_editor_for_command(manager: WorkspaceManager, command: list[str]):
+    """Resolve a command path (no 'aaz' root) to (cfg_editor, *node_names, leaf_name)."""
+    if not command or len(command) < 2:
+        raise exceptions.InvalidAPIUsage(
+            "command path must include at least one group and a leaf")
+    *node_names, leaf_name = command
+    leaf = manager.find_command_tree_leaf(*node_names, leaf_name)
+    if not leaf:
+        raise exceptions.ResourceNotFind(
+            f"Command not found: {' '.join(command)}")
+    cfg_editor = manager.load_cfg_editor_by_command(leaf)
+    return cfg_editor, node_names, leaf_name
+
+
+def update_argument(
+    name: str,
+    command: list[str],
+    arg_var: str,
+    options: Optional[list[str]] = None,
+    singular_options: Optional[list[str]] = None,
+    help: Optional[dict] = None,
+    stage: Optional[str] = None,
+    hide: Optional[bool] = None,
+    group: Optional[str] = None,
+    clear_group: bool = False,
+    default: Any = "__unset__",
+    required: Optional[bool] = None,  # currently unused; reserved
+) -> dict:
+    """Patch a single argument of a leaf command.
+
+    Mirrors PATCH /Workspaces/<ws>/.../Arguments/<arg_var> in the editor API.
+
+    - command: full command path without the 'aaz' root, e.g.
+      ['consumption', 'budget', 'create'].
+    - arg_var: argument variable, e.g. '$Path.budgetName' or
+      '$parameters.properties.timePeriod'. Inspect with the editor UI or
+      look at the workspace's cfg.json.
+    - options: replace the argument's option list (e.g. ['name', 'n', 'budget-name']
+      to add aliases to --budget-name).
+    - singular_options: only valid for array / cls args; used by the UI when
+      promoting a multi-value option to also accept a singular form.
+    - help: {'short': str, 'lines': [str], 'refCommands': [str]}.
+    - stage: 'Stable' | 'Preview' | 'Experimental'.
+    - hide: bool. (Cannot hide required arguments.)
+    - group: arg group name. Pass a non-empty string to set; pass
+      ``clear_group=True`` to remove the arg from any named group
+      (it then appears in the default un-named group).
+    - clear_group: if True, set ``arg.group`` back to None. Takes
+      precedence over ``group``. Use this instead of passing an empty
+      string, which some MCP transports mangle.
+    - default: pass any JSON value, or null to clear; omit (sentinel) to leave alone.
+    """
+    manager = WorkspaceManager(name)
+    manager.load()
+    cfg_editor, node_names, leaf_name = _load_cfg_editor_for_command(manager, command)
+    arg, _ = cfg_editor.find_arg_by_var(*node_names, leaf_name, arg_var=arg_var)
+    if not arg:
+        raise exceptions.ResourceNotFind(
+            f"Argument not found on {' '.join(command)}: {arg_var}")
+
+    kwargs: dict[str, Any] = {}
+    if options is not None:
+        kwargs["options"] = options
+    if singular_options is not None:
+        kwargs["singularOptions"] = singular_options
+    if help is not None:
+        kwargs["help"] = help
+    if stage is not None:
+        kwargs["stage"] = stage
+    if hide is not None:
+        kwargs["hide"] = hide
+    if clear_group:
+        kwargs["group"] = None
+    elif group is not None:
+        kwargs["group"] = group
+    if default != "__unset__":
+        kwargs["default"] = default
+    if not kwargs:
+        raise exceptions.InvalidAPIUsage(
+            "update_argument requires at least one field to change")
+
+    cfg_editor.update_arg_by_var(*node_names, leaf_name, arg_var=arg_var, **kwargs)
+    manager.save()
+    arg, _ = cfg_editor.find_arg_by_var(*node_names, leaf_name, arg_var=arg_var)
+    return arg.to_primitive()
+
+
+def flatten_argument(
+    name: str,
+    command: list[str],
+    arg_var: str,
+    sub_args_options: Optional[dict[str, list[str]]] = None,
+) -> dict:
+    """Flatten an object argument into its sub-arguments.
+
+    Mirrors POST /Workspaces/<ws>/.../Arguments/<arg_var>/Flatten.
+
+    Example: flatten ``$parameters.properties.timePeriod`` on
+    ``consumption budget create`` so that the user sees ``--start-date``
+    and ``--end-date`` directly instead of ``--time-period``.
+
+    - command: full command path without the 'aaz' root.
+    - arg_var: object argument variable to flatten.
+    - sub_args_options: optional ``{sub_arg_var: [option, ...]}`` mapping
+      to rename the flattened sub-arguments.
+    """
+    manager = WorkspaceManager(name)
+    manager.load()
+    cfg_editor, node_names, leaf_name = _load_cfg_editor_for_command(manager, command)
+    arg, _ = cfg_editor.find_arg_by_var(*node_names, leaf_name, arg_var=arg_var)
+    if not arg:
+        raise exceptions.ResourceNotFind(
+            f"Argument not found on {' '.join(command)}: {arg_var}")
+    cfg_editor.flatten_arg(
+        *node_names, leaf_name, arg_var=arg_var, sub_args_options=sub_args_options)
+    manager.save()
+    return {
+        "command": command,
+        "flattened": arg_var,
+        "sub_args_options": sub_args_options or {},
+    }
+
+
+def unflatten_argument(
+    name: str,
+    command: list[str],
+    arg_var: str,
+    options: list[str],
+    help: dict,
+    sub_args_options: Optional[dict[str, list[str]]] = None,
+) -> dict:
+    """Inverse of flatten_argument: re-wrap sub-args under a single object arg."""
+    manager = WorkspaceManager(name)
+    manager.load()
+    cfg_editor, node_names, leaf_name = _load_cfg_editor_for_command(manager, command)
+    cfg_editor.unflatten_arg(
+        *node_names, leaf_name, arg_var=arg_var,
+        options=options, help=help, sub_args_options=sub_args_options)
+    manager.save()
+    arg, _ = cfg_editor.find_arg_by_var(*node_names, leaf_name, arg_var=arg_var)
+    return arg.to_primitive()

--- a/src/aaz_dev_mcp/services/command/examples.py
+++ b/src/aaz_dev_mcp/services/command/examples.py
@@ -1,0 +1,108 @@
+"""Example management on workspace command leaves.
+
+Mirrors backend ``command/controller/workspace_manager.py`` example operations
+plus ``swagger/controller/example_generator.py`` for swagger-derived examples.
+"""
+
+from __future__ import annotations
+
+import aaz_dev  # noqa: F401  (injects src/aaz_dev onto sys.path)
+from command.controller.workspace_manager import WorkspaceManager
+from utils import exceptions
+
+
+def _find_leaf(manager: WorkspaceManager, command: list[str]):
+    if not command or len(command) < 2:
+        raise exceptions.InvalidAPIUsage(
+            "command path must include at least one group and a leaf")
+    *node_names, leaf_name = command
+    leaf = manager.find_command_tree_leaf(*node_names, leaf_name)
+    if not leaf:
+        raise exceptions.ResourceNotFind(
+            f"Command not found: {' '.join(command)}")
+    return leaf
+
+
+def list_command_examples(name: str, command: list[str]) -> list[dict]:
+    """Return the current examples on a leaf command."""
+    manager = WorkspaceManager(name)
+    manager.load()
+    leaf = _find_leaf(manager, command)
+    return [e.to_primitive() for e in (leaf.examples or [])]
+
+
+def set_command_examples(
+    name: str,
+    command: list[str],
+    examples: list[dict],
+) -> list[dict]:
+    """Replace the full example list on a leaf command.
+
+    Each example must have ``{"name": str, "commands": [str, ...]}``.
+    Pass an empty list to clear examples.
+    """
+    manager = WorkspaceManager(name)
+    manager.load()
+    leaf = _find_leaf(manager, command)
+    leaf = manager.update_command_tree_leaf_examples(*leaf.names, examples=examples)
+    manager.save()
+    return [e.to_primitive() for e in (leaf.examples or [])]
+
+
+def add_command_example(
+    name: str,
+    command: list[str],
+    example_name: str,
+    commands: list[str],
+) -> list[dict]:
+    """Append a single manual example to a leaf command.
+
+    - example_name: short label shown in CLI help
+    - commands: list of CLI invocation strings, e.g.
+      ['consumption budget create -n my-budget --amount 100 ...']
+    """
+    if not example_name or not commands:
+        raise exceptions.InvalidAPIUsage(
+            "example_name and commands must be non-empty")
+    manager = WorkspaceManager(name)
+    manager.load()
+    leaf = _find_leaf(manager, command)
+    existing = [e.to_primitive() for e in (leaf.examples or [])]
+    existing.append({"name": example_name, "commands": list(commands)})
+    leaf = manager.update_command_tree_leaf_examples(*leaf.names, examples=existing)
+    manager.save()
+    return [e.to_primitive() for e in (leaf.examples or [])]
+
+
+def add_examples_from_swagger(
+    name: str,
+    command: list[str],
+    replace: bool = False,
+) -> list[dict]:
+    """Generate examples from the OpenAPI specification ('By OpenAPI Specification'
+    button in the UI) and persist them on the leaf.
+
+    - replace=False (default): append generated examples to any existing ones.
+    - replace=True: drop existing examples first.
+    """
+    manager = WorkspaceManager(name)
+    manager.load()
+    leaf = _find_leaf(manager, command)
+    cfg_editor = manager.load_cfg_editor_by_command(leaf)
+    cfg_command = cfg_editor.find_command(*leaf.names)
+    if not cfg_command:
+        raise exceptions.ResourceNotFind(
+            f"Command config not found: {' '.join(command)}")
+
+    generated = manager.generate_examples_by_swagger(leaf, cfg_command)
+    generated_dicts = [e.to_primitive() for e in generated]
+
+    if replace:
+        merged = generated_dicts
+    else:
+        merged = [e.to_primitive() for e in (leaf.examples or [])]
+        merged.extend(generated_dicts)
+
+    leaf = manager.update_command_tree_leaf_examples(*leaf.names, examples=merged)
+    manager.save()
+    return [e.to_primitive() for e in (leaf.examples or [])]

--- a/src/aaz_dev_mcp/services/command/workspaces.py
+++ b/src/aaz_dev_mcp/services/command/workspaces.py
@@ -1,0 +1,191 @@
+"""Workspace lifecycle operations: thin wrappers around WorkspaceManager.
+
+Mirrors the backend ``command/controller/workspace_manager.py`` surface that
+deals with the workspace itself (create/load/list/save) and its command tree
+(rename nodes/leaves, set help, add swagger resources, generate to aaz).
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Iterable, Optional
+
+import aaz_dev  # noqa: F401  (injects src/aaz_dev onto sys.path)
+from command.controller.workspace_manager import WorkspaceManager
+from swagger.utils.tools import swagger_resource_path_to_resource_id
+from utils import exceptions
+
+
+def list_workspaces() -> list[dict]:
+    return WorkspaceManager.list_workspaces()
+
+
+def create_workspace(
+    name: str,
+    plane: str,
+    mod_names: str,
+    resource_provider: str,
+    source: str,
+) -> dict:
+    """Create a new workspace. Raises ResourceConflict if it already exists.
+
+    WorkspaceManager.new already enforces "fails if exists" via a
+    ResourceConflict check on the ws.json path (workspace_manager.py:52-54).
+    """
+    manager = WorkspaceManager.new(
+        name=name,
+        plane=plane,
+        mod_names=mod_names,
+        resource_provider=resource_provider,
+        source=source,
+    )
+    manager.save()
+    return _ws_summary(manager)
+
+
+def load_workspace(name: str) -> dict:
+    manager = WorkspaceManager(name)
+    manager.load()
+    return _ws_summary(manager)
+
+
+def add_swagger_resources(
+    name: str,
+    module: str,
+    version: str,
+    resource_paths: Iterable[str],
+) -> dict:
+    """Add resources to a workspace's command tree by swagger path.
+
+    ``resource_paths`` are raw swagger paths (e.g.
+    ``/subscriptions/{subscriptionId}/providers/Microsoft.Consumption/budgets``);
+    they are normalized to resource ids using the same helper the Flask layer
+    uses.
+    """
+    manager = WorkspaceManager(name)
+    manager.load()
+    resources = [
+        {"id": swagger_resource_path_to_resource_id(p)}
+        for p in resource_paths
+    ]
+    if not resources:
+        raise exceptions.InvalidAPIUsage("resource_paths must not be empty")
+    manager.add_new_resources_by_swagger(
+        mod_names=module,
+        version=version,
+        resources=resources,
+    )
+    manager.save()
+    return {"added": [r["id"] for r in resources]}
+
+
+def set_node_help(
+    name: str,
+    node_names: list[str],
+    help: Optional[dict] = None,
+    stage: Optional[str] = None,
+) -> dict:
+    """Update help and/or stage on a command-tree node (group).
+
+    ``node_names`` should NOT include the root "aaz" prefix; pass the
+    user-visible names, e.g. ``["consumption", "budget"]``.
+    """
+    manager = WorkspaceManager(name)
+    manager.load()
+    node = None
+    if help is not None:
+        node = manager.update_command_tree_node_help(*node_names, help=help)
+    if stage is not None:
+        node = manager.update_command_tree_node_stage(*node_names, stage=stage)
+    if node is None:
+        raise exceptions.InvalidAPIUsage(
+            "set_node_help requires at least one of 'help' or 'stage'")
+    manager.save()
+    return node.to_primitive()
+
+
+def set_command_help(
+    name: str,
+    leaf_names: list[str],
+    help: Optional[dict] = None,
+    stage: Optional[str] = None,
+) -> dict:
+    """Update help and/or stage on a command-tree leaf (command).
+
+    ``leaf_names`` excludes the implicit 'aaz' root, e.g.
+    ``["consumption", "budget", "create"]``.
+    """
+    manager = WorkspaceManager(name)
+    manager.load()
+    leaf = None
+    if help is not None:
+        leaf = manager.update_command_tree_leaf_help(*leaf_names, help=help)
+    if stage is not None:
+        leaf = manager.update_command_tree_leaf_stage(*leaf_names, stage=stage)
+    if leaf is None:
+        raise exceptions.InvalidAPIUsage(
+            "set_command_help requires at least one of 'help' or 'stage'")
+    manager.save()
+    return leaf.to_primitive()
+
+
+def generate_to_aaz(name: str) -> dict:
+    """Export the workspace's command tree into the aaz repo."""
+    manager = WorkspaceManager(name)
+    manager.load()
+    manager.generate_to_aaz()
+    return {"workspace": name, "status": "generated"}
+
+
+def rename_command_group(
+    name: str,
+    node_names: list[str],
+    new_node_names: list[str],
+) -> dict:
+    """Rename a command-tree group (node).
+
+    ``node_names`` and ``new_node_names`` exclude the implicit 'aaz' root.
+    Example: rename ``['consumption', 'usage-detail']`` to
+    ``['consumption', 'usage']``.
+    """
+    manager = WorkspaceManager(name)
+    manager.load()
+    if not node_names or not new_node_names:
+        raise exceptions.InvalidAPIUsage(
+            "node_names and new_node_names must be non-empty")
+    node = manager.rename_command_tree_node(
+        *node_names, new_node_names=new_node_names)
+    manager.save()
+    return node.to_primitive() if node is not None else {
+        "from": node_names, "to": new_node_names, "noop": True}
+
+
+def rename_command(
+    name: str,
+    leaf_names: list[str],
+    new_leaf_names: list[str],
+) -> dict:
+    """Rename a command-tree leaf (command).
+
+    ``leaf_names`` and ``new_leaf_names`` exclude the implicit 'aaz' root.
+    Example: rename ``['consumption', 'pricesheet', 'default', 'show']`` to
+    ``['consumption', 'pricesheet', 'show']``.
+    """
+    manager = WorkspaceManager(name)
+    manager.load()
+    if not leaf_names or not new_leaf_names:
+        raise exceptions.InvalidAPIUsage(
+            "leaf_names and new_leaf_names must be non-empty")
+    leaf = manager.rename_command_tree_leaf(
+        *leaf_names, new_leaf_names=new_leaf_names)
+    manager.save()
+    return leaf.to_primitive() if leaf is not None else {
+        "from": leaf_names, "to": new_leaf_names, "noop": True}
+
+
+def _ws_summary(manager: WorkspaceManager) -> dict:
+    result = manager.ws.to_primitive()
+    result["folder"] = manager.folder
+    if os.path.exists(manager.path):
+        result["updated"] = os.path.getmtime(manager.path)
+    return result

--- a/src/aaz_dev_mcp/tools/__init__.py
+++ b/src/aaz_dev_mcp/tools/__init__.py
@@ -1,0 +1,20 @@
+"""FastMCP tool registrations.
+
+Mirrors the ``services/`` layout: every domain submodule exposes a
+``register(mcp)`` entry point that wires its ``@mcp.tool()`` callables.
+``register_tools`` simply dispatches to each domain in turn.
+"""
+
+from __future__ import annotations
+
+from mcp.server.fastmcp import FastMCP
+
+from . import config as _config
+from .command import register as _register_command
+from .cli import register as _register_cli
+
+
+def register_tools(mcp: FastMCP) -> None:
+    _config.register(mcp)
+    _register_command(mcp)
+    _register_cli(mcp)

--- a/src/aaz_dev_mcp/tools/cli/__init__.py
+++ b/src/aaz_dev_mcp/tools/cli/__init__.py
@@ -1,0 +1,11 @@
+"""CLI-domain tool registrations."""
+
+from __future__ import annotations
+
+from mcp.server.fastmcp import FastMCP
+
+from . import modules as _modules
+
+
+def register(mcp: FastMCP) -> None:
+    _modules.register(mcp)

--- a/src/aaz_dev_mcp/tools/cli/modules.py
+++ b/src/aaz_dev_mcp/tools/cli/modules.py
@@ -1,0 +1,80 @@
+"""CLI module tools (get/update/select)."""
+
+from __future__ import annotations
+
+from mcp.server.fastmcp import FastMCP
+
+
+def register(mcp: FastMCP) -> None:
+    @mcp.tool()
+    def get_main_module(module_name: str) -> dict:
+        """Load the current azure-cli main module's command profile."""
+        from ...services.cli import modules
+        return modules.get_module("main", module_name)
+
+    @mcp.tool()
+    def get_extension_module(module_name: str) -> dict:
+        """Load the current azure-cli-extensions module's command profile."""
+        from ...services.cli import modules
+        return modules.get_module("extension", module_name)
+
+    @mcp.tool()
+    def update_main_module(
+        module_name: str,
+        profiles: dict,
+        by_patch: bool = True,
+    ) -> dict:
+        """Generate CLI code for an azure-cli main module from a profiles dict.
+
+        See the `select_command_versions` tool for a higher-level helper that
+        builds `profiles` from a flat command -> version map.
+        """
+        from ...services.cli import modules
+        return modules.update_module(
+            "main", module_name, profiles, by_patch=by_patch)
+
+    @mcp.tool()
+    def update_extension_module(
+        module_name: str,
+        profiles: dict,
+        by_patch: bool = True,
+    ) -> dict:
+        """Generate CLI code for an azure-cli-extensions module from a
+        profiles dict."""
+        from ...services.cli import modules
+        return modules.update_module(
+            "extension", module_name, profiles, by_patch=by_patch)
+
+    @mcp.tool()
+    def select_command_versions(
+        target: str,
+        module_name: str,
+        command_versions: dict,
+        profile: str = "latest",
+        by_patch: bool = True,
+    ) -> dict:
+        """Pick specific versions for specific commands and generate CLI code.
+
+        - target: 'main' (azure-cli) or 'extension' (azure-cli-extensions)
+        - module_name: CLI module name, e.g. 'consumption'
+        - command_versions: map of full command path -> API version. Example::
+
+              {
+                "consumption budget create": "2024-08-01",
+                "consumption budget delete": "2024-08-01"
+              }
+
+        - profile: CLI profile name, default 'latest'
+        - by_patch: True (default) merges with existing commands; False
+          overwrites the whole profile.
+
+        All commands are marked registered=True.
+        """
+        from ...services.cli import modules
+        return modules.select_command_versions(
+            target=target,
+            module_name=module_name,
+            profile=profile,
+            command_versions=command_versions,
+            by_patch=by_patch,
+        )

--- a/src/aaz_dev_mcp/tools/command/__init__.py
+++ b/src/aaz_dev_mcp/tools/command/__init__.py
@@ -1,0 +1,15 @@
+"""Command-domain tool registrations."""
+
+from __future__ import annotations
+
+from mcp.server.fastmcp import FastMCP
+
+from . import workspaces as _workspaces
+from . import arguments as _arguments
+from . import examples as _examples
+
+
+def register(mcp: FastMCP) -> None:
+    _workspaces.register(mcp)
+    _arguments.register(mcp)
+    _examples.register(mcp)

--- a/src/aaz_dev_mcp/tools/command/arguments.py
+++ b/src/aaz_dev_mcp/tools/command/arguments.py
@@ -1,0 +1,89 @@
+"""Argument-editing tools (patch / flatten / unflatten)."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from mcp.server.fastmcp import FastMCP
+
+
+def register(mcp: FastMCP) -> None:
+    @mcp.tool()
+    def update_argument(
+        name: str,
+        command: list[str],
+        arg_var: str,
+        options: Optional[list[str]] = None,
+        singular_options: Optional[list[str]] = None,
+        help: Optional[dict] = None,
+        stage: Optional[str] = None,
+        hide: Optional[bool] = None,
+        group: Optional[str] = None,
+        clear_group: bool = False,
+    ) -> dict:
+        """Patch a single argument on a leaf command.
+
+        Use this to add aliases (e.g. expose --budget-name also as --name / -n)
+        or to tweak help / stage / group.
+
+        - name: workspace name
+        - command: full command path without the 'aaz' root, e.g.
+          ['consumption', 'budget', 'create']
+        - arg_var: argument variable, e.g. '$Path.budgetName'
+        - options: replace the argument's option list, e.g.
+          ['name', 'n', 'budget-name'] (the first option becomes the
+          primary --name; subsequent become aliases)
+        - singular_options: alternative singular form for array / cls args
+        - help: {'short': str, 'lines': [str], 'refCommands': [str]}
+        - stage: 'Stable' | 'Preview' | 'Experimental'
+        - hide: bool (cannot hide required args)
+        - group: arg group name (non-empty); to remove from a group,
+          use ``clear_group=True`` instead of passing an empty string.
+        - clear_group: if True, ungroup the argument (places it in the
+          default un-named group). Takes precedence over ``group``.
+        """
+        from ...services.command import arguments
+        return arguments.update_argument(
+            name=name, command=command, arg_var=arg_var,
+            options=options, singular_options=singular_options,
+            help=help, stage=stage, hide=hide, group=group,
+            clear_group=clear_group)
+
+    @mcp.tool()
+    def flatten_argument(
+        name: str,
+        command: list[str],
+        arg_var: str,
+        sub_args_options: Optional[dict[str, list[str]]] = None,
+    ) -> dict:
+        """Flatten an object argument into its sub-arguments.
+
+        Example: flatten '$parameters.properties.timePeriod' on
+        'consumption budget create' so users get --start-date / --end-date
+        directly instead of having to pass --time-period as a JSON object.
+
+        - name: workspace name
+        - command: full command path without the 'aaz' root
+        - arg_var: object argument variable to flatten
+        - sub_args_options: optional rename map, e.g.
+          {'$parameters.properties.timePeriod.startDate': ['start-date']}
+        """
+        from ...services.command import arguments
+        return arguments.flatten_argument(
+            name=name, command=command, arg_var=arg_var,
+            sub_args_options=sub_args_options)
+
+    @mcp.tool()
+    def unflatten_argument(
+        name: str,
+        command: list[str],
+        arg_var: str,
+        options: list[str],
+        help: dict,
+        sub_args_options: Optional[dict[str, list[str]]] = None,
+    ) -> dict:
+        """Inverse of flatten_argument: collapse sub-args back into one object arg."""
+        from ...services.command import arguments
+        return arguments.unflatten_argument(
+            name=name, command=command, arg_var=arg_var,
+            options=options, help=help, sub_args_options=sub_args_options)

--- a/src/aaz_dev_mcp/tools/command/examples.py
+++ b/src/aaz_dev_mcp/tools/command/examples.py
@@ -1,0 +1,72 @@
+"""Command-example tools (list / add / generate-from-swagger / set)."""
+
+from __future__ import annotations
+
+from mcp.server.fastmcp import FastMCP
+
+
+def register(mcp: FastMCP) -> None:
+    @mcp.tool()
+    def list_command_examples(name: str, command: list[str]) -> list[dict]:
+        """Return the current examples on a leaf command.
+
+        - name: workspace name
+        - command: full command path without the 'aaz' root
+        """
+        from ...services.command import examples
+        return examples.list_command_examples(name=name, command=command)
+
+    @mcp.tool()
+    def add_command_example(
+        name: str,
+        command: list[str],
+        example_name: str,
+        commands: list[str],
+    ) -> list[dict]:
+        """Append a single manually-authored example to a leaf command.
+
+        Mirrors typing in the editor's "Add Example" dialog.
+
+        - name: workspace name
+        - command: full command path without the 'aaz' root, e.g.
+          ['consumption', 'budget', 'create']
+        - example_name: short label shown in CLI help
+        - commands: list of CLI invocation strings, e.g.
+          ['consumption budget create -n my-budget --amount 100 --category Cost ...']
+
+        Returns the full updated example list.
+        """
+        from ...services.command import examples
+        return examples.add_command_example(
+            name=name, command=command,
+            example_name=example_name, commands=commands)
+
+    @mcp.tool()
+    def add_examples_from_swagger(
+        name: str,
+        command: list[str],
+        replace: bool = False,
+    ) -> list[dict]:
+        """Generate examples from the OpenAPI spec (the editor's
+        'By OpenAPI Specification' button) and persist them on the leaf.
+
+        - replace=False (default): append generated examples to existing ones.
+        - replace=True: drop existing examples first.
+
+        Returns the full updated example list.
+        """
+        from ...services.command import examples
+        return examples.add_examples_from_swagger(
+            name=name, command=command, replace=replace)
+
+    @mcp.tool()
+    def set_command_examples(
+        name: str,
+        command: list[str],
+        examples: list[dict],
+    ) -> list[dict]:
+        """Replace all examples on a leaf command. Each example is
+        ``{"name": str, "commands": [str, ...]}``. Pass [] to clear."""
+        from ...services.command import examples as cmd_examples
+        return cmd_examples.set_command_examples(
+            name=name, command=command, examples=examples)

--- a/src/aaz_dev_mcp/tools/command/workspaces.py
+++ b/src/aaz_dev_mcp/tools/command/workspaces.py
@@ -1,0 +1,158 @@
+"""Workspace lifecycle + command-tree edit tools."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from mcp.server.fastmcp import FastMCP
+
+
+def register(mcp: FastMCP) -> None:
+    @mcp.tool()
+    def list_workspaces() -> list[dict]:
+        """List existing workspaces in the configured workspace folder."""
+        from ...services.command import workspaces
+        return workspaces.list_workspaces()
+
+    @mcp.tool()
+    def create_workspace(
+        name: str,
+        mod_names: str,
+        resource_provider: str,
+        plane: str = "mgmt-plane",
+        source: str = "OpenAPI",
+    ) -> dict:
+        """Create a new workspace. Errors if a workspace with this name
+        already exists.
+
+        - name: workspace name (becomes the folder name on disk)
+        - mod_names: swagger module path under specification/, e.g.
+          'consumption' or 'compute/Microsoft.Compute'
+        - resource_provider: the ARM RP name, e.g. 'Microsoft.Consumption'
+        - plane: 'mgmt-plane' (default) or 'data-plane'
+        - source: 'OpenAPI' (default) or 'TypeSpec'
+        """
+        from ...services.command import workspaces
+        return workspaces.create_workspace(
+            name=name,
+            plane=plane,
+            mod_names=mod_names,
+            resource_provider=resource_provider,
+            source=source,
+        )
+
+    @mcp.tool()
+    def load_workspace(name: str) -> dict:
+        """Load an existing workspace and return its command tree.
+
+        Returns the workspace's command tree as a dict.
+        """
+        from ...services.command import workspaces
+        return workspaces.load_workspace(name)
+
+    @mcp.tool()
+    def add_swagger_resources(
+        name: str,
+        module: str,
+        version: str,
+        resource_paths: list[str],
+    ) -> dict:
+        """Add Azure REST API swagger resources to a workspace.
+
+        The resource_paths are the raw URL templates from the swagger spec,
+        e.g. '/subscriptions/{subscriptionId}/providers/Microsoft.Consumption/budgets'.
+        They are normalized to resource ids automatically.
+
+        - name: workspace name
+        - module: swagger module (e.g. 'consumption')
+        - version: API version (e.g. '2024-08-01')
+        - resource_paths: list of swagger paths
+        """
+        from ...services.command import workspaces
+        return workspaces.add_swagger_resources(
+            name=name,
+            module=module,
+            version=version,
+            resource_paths=resource_paths,
+        )
+
+    @mcp.tool()
+    def set_node_help(
+        name: str,
+        node_names: list[str],
+        help: Optional[dict] = None,
+        stage: Optional[str] = None,
+    ) -> dict:
+        """Update help text and/or stage on a command-group node.
+
+        - name: workspace name
+        - node_names: path to the group, e.g. ['consumption', 'budget']
+          (do NOT include the implicit 'aaz' root)
+        - help: dict with 'short' and optional 'lines'; e.g.
+          {'short': 'Manage consumption budgets.'}
+        - stage: one of 'Stable', 'Preview', 'Experimental'
+        """
+        from ...services.command import workspaces
+        return workspaces.set_node_help(
+            name=name, node_names=node_names, help=help, stage=stage)
+
+    @mcp.tool()
+    def set_command_help(
+        name: str,
+        leaf_names: list[str],
+        help: Optional[dict] = None,
+        stage: Optional[str] = None,
+    ) -> dict:
+        """Update help text and/or stage on a leaf command.
+
+        - name: workspace name
+        - leaf_names: full command path, e.g. ['consumption', 'budget', 'create']
+          (do NOT include the implicit 'aaz' root)
+        - help: dict with 'short' and optional 'lines'
+        - stage: one of 'Stable', 'Preview', 'Experimental'
+        """
+        from ...services.command import workspaces
+        return workspaces.set_command_help(
+            name=name, leaf_names=leaf_names, help=help, stage=stage)
+
+    @mcp.tool()
+    def generate_to_aaz(name: str) -> dict:
+        """Export the workspace's command tree into the configured aaz repo
+        (writes JSON/XML under the Commands/ tree)."""
+        from ...services.command import workspaces
+        return workspaces.generate_to_aaz(name)
+
+    @mcp.tool()
+    def rename_command_group(
+        name: str,
+        node_names: list[str],
+        new_node_names: list[str],
+    ) -> dict:
+        """Rename a command-tree group (e.g. rename 'consumption usage-detail'
+        to 'consumption usage'). Both lists exclude the implicit 'aaz' root.
+
+        - name: workspace name
+        - node_names: current group path, e.g. ['consumption', 'usage-detail']
+        - new_node_names: target path, e.g. ['consumption', 'usage']
+        """
+        from ...services.command import workspaces
+        return workspaces.rename_command_group(
+            name=name, node_names=node_names, new_node_names=new_node_names)
+
+    @mcp.tool()
+    def rename_command(
+        name: str,
+        leaf_names: list[str],
+        new_leaf_names: list[str],
+    ) -> dict:
+        """Rename a command-tree leaf (e.g. rename
+        'consumption pricesheet default show' to 'consumption pricesheet show').
+        Both lists exclude the implicit 'aaz' root.
+
+        - name: workspace name
+        - leaf_names: current command path
+        - new_leaf_names: target command path
+        """
+        from ...services.command import workspaces
+        return workspaces.rename_command(
+            name=name, leaf_names=leaf_names, new_leaf_names=new_leaf_names)

--- a/src/aaz_dev_mcp/tools/config.py
+++ b/src/aaz_dev_mcp/tools/config.py
@@ -1,0 +1,42 @@
+"""``configure`` tool — wires repo paths used by aaz-dev-tools."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from mcp.server.fastmcp import FastMCP
+
+
+def register(mcp: FastMCP) -> None:
+    @mcp.tool()
+    def configure(
+        aaz_path: Optional[str] = None,
+        swagger_path: Optional[str] = None,
+        cli_path: Optional[str] = None,
+        cli_extension_path: Optional[str] = None,
+        workspace_folder: Optional[str] = None,
+    ) -> dict:
+        """Configure repository paths used by aaz-dev-tools.
+
+        All arguments are optional; only the ones provided are updated. Pass
+        no arguments to inspect the current values. Paths are validated for
+        existence; invalid paths raise an error.
+
+        - aaz_path: clone of github.com/Azure/aaz
+        - swagger_path: clone of github.com/Azure/azure-rest-api-specs
+        - cli_path: clone of github.com/Azure/azure-cli
+        - cli_extension_path: clone of github.com/Azure/azure-cli-extensions
+        - workspace_folder: where ws.json files are stored
+          (default ~/.aaz/workspaces)
+        """
+        from ..config import apply_config
+        try:
+            return apply_config(
+                aaz_path=aaz_path,
+                swagger_path=swagger_path,
+                cli_path=cli_path,
+                cli_extension_path=cli_extension_path,
+                workspace_folder=workspace_folder,
+            )
+        except ValueError as e:
+            return {"error": str(e)}


### PR DESCRIPTION
## Summary

Adds a [Model Context Protocol](https://modelcontextprotocol.io) server at `src/mcp/` that exposes aaz-dev-tools workflows (workspace management, swagger import, CLI codegen) as tools an LLM agent can call. The server reuses the same Python controllers as the Flask web UI, so generated CLI code is identical to clicking through the browser.

Shipped as a separate distribution (`aaz-dev-mcp`) that depends on `aaz-dev-tools` being installed in the same environment.

## What's included

- `src/mcp/aaz_dev_mcp/` — FastMCP server (`server.py`), tool definitions (`tools.py`), service-layer wrappers for workspaces and CLI modules.
- `src/mcp/pyproject.toml` — installable as `aaz-dev-mcp`, exposes the `aaz-dev-mcp` console script.
- `src/mcp/README.md` — tool list, env vars, agent config snippets, and a worked example.
- `src/mcp/examples/consumption_2024_08_01.json` — reproducing [azure-cli#33222](https://github.com/Azure/azure-cli/pull/33222) end-to-end.
- `Makefile` — `make mcp-install` / `make mcp` shortcuts.

## Try it

```bash
make mcp-install
make mcp
```

Then point an MCP-capable client (Claude Desktop, etc.) at the `aaz-dev-mcp` stdio command.

## Notes

- Draft: the MCP package shape may still evolve (tool naming, error envelopes). Feedback welcome before un-drafting.
- Verified end-to-end against the consumption swagger 2023-05-01 → 2024-08-01 upgrade.