### PR TITLE
build: unpin setuptools to align with Azure CLI (<81)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+4.6.1
+++++++
+* Unpinned ``setuptools`` (was ``==70.0.0``) to allow newer versions, capped at ``<81`` because setuptools 81+ drops ``setup.py``-based build support.
+
 4.6.0
 ++++++
 * Upgrade `@typespec/compiler` to 1.13.0. (#558)

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -36,7 +36,7 @@ github:
 pypi: https://pypi.org/project/aaz-dev/
 
 # TODO: get version number from github
-version: v4.6.0
+version: v4.6.1
 
 # Build settings
 theme: minima

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ Jinja2~=3.1.4
 MarkupSafe>=2.1.5
 jsonschema~=4.23.0
 click~=8.1.2
-setuptools==70.0.0
+setuptools<81
 python-Levenshtein
 azure-mgmt-core
 azdev

--- a/version.py
+++ b/version.py
@@ -1,5 +1,5 @@
 
-_MAJOR, _MINOR, _PATCH, _SUFFIX = ("4", "6", "0", "")
+_MAJOR, _MINOR, _PATCH, _SUFFIX = ("4", "6", "1", "")
 
 # _PATCH: On main and in a nightly release the patch should be one ahead of the last released build.
 # _SUFFIX: This is mainly for nightly builds which have the suffix ".dev$DATE". See


### PR DESCRIPTION
### Summary
Unpin `setuptools` (was `==70.0.0`) to `<81` so aaz-dev-tools stays consistent with Azure CLI and its extensions, which have already dropped their setuptools/wheel pins.

### Why cap at `<81`
setuptools 81 removes support for `setup.py`-based builds, which this project still relies on. Capping just below 81 lets us pick up newer releases while keeping the build working.

### Changes
- `requirements.txt`: `setuptools==70.0.0` -> `setuptools<81`
- Bump version to 4.6.1 and add a HISTORY entry

Closes #557