### PR TITLE
[Build] drop setuptools upper bound, keep CVE floor (>=78.1.1)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+4.6.2
+++++++
+* Remove the ``setuptools<81`` upper bound; require ``setuptools>=78.1.1`` instead (includes the CVE-2025-47273 fix). aaz-dev only renders ``setup.py`` templates and never executes them, so newer setuptools does not affect it; in a shared dev environment the effective version is still bounded by ``azdev``'s own ``setuptools`` requirement.
+
 4.6.1
 ++++++
 * Unpinned ``setuptools`` (was ``==70.0.0``) to allow newer versions, capped at ``<81`` because setuptools 81+ drops ``setup.py``-based build support.

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ Jinja2~=3.1.4
 MarkupSafe>=2.1.5
 jsonschema~=4.23.0
 click~=8.1.2
-setuptools<81
+setuptools>=78.1.1
 python-Levenshtein
 azure-mgmt-core
 azdev

--- a/version.py
+++ b/version.py
@@ -1,5 +1,5 @@
 
-_MAJOR, _MINOR, _PATCH, _SUFFIX = ("4", "6", "1", "")
+_MAJOR, _MINOR, _PATCH, _SUFFIX = ("4", "6", "2", "")
 
 # _PATCH: On main and in a nightly release the patch should be one ahead of the last released build.
 # _SUFFIX: This is mainly for nightly builds which have the suffix ".dev$DATE". See


### PR DESCRIPTION
`aaz-dev` only renders `setup.py` templates for generated extensions and never executes them, so the `setuptools<81` cap added in 4.6.1 is not load-bearing here. 

This PR replace it with the `>=78.1.1 floor (CVE-2025-47273)` so this repo no longer blocks the ecosystem-wide unpin. In shared dev environments the effective version is still bounded by azdev's own setuptools requirement until azdev lifts its cap.