### PR TITLE
Fix typos in docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -138,7 +138,7 @@ methods:
 This resource will be translated into four commands under `az edge-order address` command group:
 
 ```yaml
-az data-bricks workspace:
+az edge-order address:
     - show
     - delete
     - create

--- a/docs/README.md
+++ b/docs/README.md
@@ -135,10 +135,10 @@ methods:
     - PATCH
 ```
 
-This resource will be translated into four commands under `az edge-order address` command group:
+This resource will be translated into four commands under `az edge-order addresses` command group:
 
 ```yaml
-az edge-order address:
+az edge-order addresses:
     - show
     - delete
     - create

--- a/docs/pages/usage/cli_generator.md
+++ b/docs/pages/usage/cli_generator.md
@@ -73,7 +73,7 @@ When you unpick some commands in selection and regenerate the code, the unpicked
 
 ### About profiles
 
-In azure-cli, there are 5 profiles right now. The `latest` profile will contains all the commands in the **latest** version, the rest profiles are used to support azure stack. You can reference the following links to learn more about azure stack:
+In azure-cli, there are 5 profiles right now. The `latest` profile contains all the commands in the **latest** version and the rest of the profiles are used to support azure stack. You can reference the following links to learn more about azure stack:
 
 - [Manage API version profiles in Azure Stack Hub](https://learn.microsoft.com/en-us/azure-stack/user/azure-stack-version-profiles?view=azs-2301)
 - [Profiles in azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs/tree/main/profile)

--- a/docs/pages/usage/workspace_editor.md
+++ b/docs/pages/usage/workspace_editor.md
@@ -345,7 +345,7 @@ While editing the arguments, you can hide it. The code of hidden arguments will 
 
 ![hidden_arguments](../../assets/recordings/workspace_editor/hidden_arguments.gif)
 
-### Support Entensible Enumeration Arguments
+### Support Extensible Enumeration Arguments
 
 Users can set enum arguments extensible for accepting other values in the future, as denoted by [x-ms-enum](https://github.com/Azure/autorest/tree/main/docs/extensions#x-ms-enum) in swagger. If `supportExtension` is set, then argument validation will be skipped when executing cmds using azure cli.
 


### PR DESCRIPTION
## Summary
- Correct the generated command example to use `az edge-order address`- align the YAML snippet with the surrounding documentation
- A few more typo edits